### PR TITLE
Fix large command payloads and input debug alignment

### DIFF
--- a/automation_bridge/README.md
+++ b/automation_bridge/README.md
@@ -522,7 +522,22 @@ automation_bridge.command("my_game.load_fixture", function(data)
 end)
 ```
 
-Submit strict JSON with `POST /commands?name=my_game.load_fixture&data=<url-encoded-json>&timeout_ms=30000`. The HTTP 200 response contains a command id. Poll `GET /commands?id=<id>` for `pending`, `running`, `completed`, `failed`, `cancelled`, or `timed_out`, plus the JSON result or error. `DELETE /commands?id=<id>` cancels only pending work. Lua callbacks run on the engine update thread and cannot be safely preempted; a running cancellation returns `409 command_not_cancellable`.
+Submit commands in a JSON body. The `data` field is itself a string containing
+strict JSON:
+
+```sh
+curl -fsS -X POST -H 'Content-Type: application/json' \
+  --data '{"name":"my_game.load_fixture","data":"{\"name\":\"standard\"}","timeout_ms":30000}' \
+  "$BASE/commands" | python3 -m json.tool
+```
+
+Query parameters remain supported for short curl requests, but clients should
+use the body because Defold bounds the complete request resource. The HTTP 200
+response contains a command id. Poll `GET /commands?id=<id>` for `pending`,
+`running`, `completed`, `failed`, `cancelled`, or `timed_out`, plus the JSON
+result or error. `DELETE /commands?id=<id>` cancels only pending work. Lua
+callbacks run on the engine update thread and cannot be safely preempted; a
+running cancellation returns `409 command_not_cancellable`.
 
 ### Native delivery and application acknowledgement
 
@@ -553,11 +568,18 @@ Annotations are copied into matching scene snapshots and can be queried with the
 
 ### Timeline markers
 
-`POST /markers?name=workflow_started&data=<url-encoded-json>&recording_timestamp_us=...`
-inserts a `marker` event. Native monotonic time is always recorded. The optional
-recording timestamp is caller-supplied, allowing a client to correlate markers
-with its own media or trace clock. Native video recording does not add this
-correlation automatically.
+Use a JSON body to insert a `marker` event without constraining marker data to
+the request-resource limit:
+
+```sh
+curl -fsS -X POST -H 'Content-Type: application/json' \
+  --data '{"name":"workflow_started","data":"{\"case\":7}","recording_timestamp_us":1234}' \
+  "$BASE/markers" | python3 -m json.tool
+```
+
+Native monotonic time is always recorded. The optional recording timestamp is
+caller-supplied, allowing a client to correlate markers with its own media or
+trace clock. Native video recording does not add this correlation automatically.
 
 ## Metal GPU trace capture (macOS)
 
@@ -568,17 +590,16 @@ Captures complete rendered frames to a Metal `.gputrace` on macOS when Defold is
 Schedule a one-frame capture:
 
 ```sh
-curl -fsS -X POST --get \
-  --data-urlencode "path=/tmp/fontgen.gputrace" \
+curl -fsS -X POST -H 'Content-Type: application/json' \
+  --data '{"path":"/tmp/fontgen.gputrace"}' \
   "$BASE/metal" | python3 -m json.tool
 ```
 
 Use `frames` to capture more than one frame:
 
 ```sh
-curl -fsS -X POST --get \
-  --data-urlencode "path=/tmp/fontgen.gputrace" \
-  --data-urlencode "frames=60" \
+curl -fsS -X POST -H 'Content-Type: application/json' \
+  --data '{"path":"/tmp/fontgen.gputrace","frames":60}' \
   "$BASE/metal" | python3 -m json.tool
 ```
 

--- a/automation_bridge/automation-bridge-python/README.md
+++ b/automation_bridge/automation-bridge-python/README.md
@@ -103,7 +103,7 @@ The package root exposes only `editor` and `engine`.
 - Capture and diagnostics: screenshots, historical `game.logs`, live engine
   logs, profiling, visual comparison, tracing, `game.video_recording`, and
   `game.metal_capture` on supported macOS/Metal runtimes.
-- Raw engine escape hatch: `game.request(method, path, params=..., json=...)`.
+- Raw engine escape hatch: `game.request(method, path, params=..., json_body=...)`.
 
 ## Bootstrap
 
@@ -293,11 +293,13 @@ Capability declarations may use `name>=N`. Incompatible API versions raise
 ## Raw requests
 
 Named helpers are preferred. For endpoint-level debugging, use the single raw
-escape hatch:
+escape hatch. `params` are URL query fields; use `json_body` for `POST` and
+`PUT` payloads so Defold's request-resource limit does not constrain their
+size. The former `json` spelling remains accepted as a compatibility alias:
 
 ```python
 health = game.request("GET", "/health")
-result = game.request("POST", "/coordinates/convert", json={
+result = game.request("POST", "/coordinates/convert", json_body={
     "point": {"x": 0.5, "y": 0.5},
     "from_space": "normalized_viewport",
     "to_space": "window",

--- a/automation_bridge/automation-bridge-python/automation_bridge/client.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/client.py
@@ -358,11 +358,11 @@ class InputController:
         lease: float = 5.0,
     ) -> JsonDict:
         """Acquire/renew control and configure the default exclusive input device."""
-        params = self._bridge._input_params(lease=lease)
-        params["device"] = device
+        json_body = self._bridge._input_json_body(lease=lease)
+        json_body["device"] = device
         if visualize is not None:
-            params["visualize"] = visualize
-        return self._bridge._request("PUT", "/input/configure", json_body=params)
+            json_body["visualize"] = visualize
+        return self._bridge._request("PUT", "/input/configure", json_body=json_body)
 
     def pending(self) -> List[InputReceipt]:
         """Return FIFO-ordered accepted/started input receipts."""
@@ -427,15 +427,15 @@ class InputController:
 
     def cancel(self, input_id: int, release: bool = True) -> InputReceipt:
         """Request cancellation, releasing active pointer/key state by default."""
-        params = self._bridge._input_params()
-        params.update({"input_id": input_id, "release": release})
-        return InputReceipt(self._bridge._request("POST", "/input/cancel", json_body=params))
+        json_body = self._bridge._input_json_body()
+        json_body.update({"input_id": input_id, "release": release})
+        return InputReceipt(self._bridge._request("POST", "/input/cancel", json_body=json_body))
 
     def flush(self, release: bool = True) -> JsonDict:
         """Cancel this session's active and later queued inputs."""
-        params = self._bridge._input_params()
-        params["release"] = release
-        return self._bridge._request("POST", "/input/flush", json_body=params)
+        json_body = self._bridge._input_json_body()
+        json_body["release"] = release
+        return self._bridge._request("POST", "/input/flush", json_body=json_body)
 
     def interruption_scope(
         self,
@@ -486,8 +486,8 @@ class PointerSession:
         """Append one continuous movement segment without releasing the pointer."""
         self._ensure_open()
         x, y = self._bridge._point(target)
-        params = self._bridge._input_params(lease=max(5.0, self.lease))
-        params.update(
+        json_body = self._bridge._input_json_body(lease=max(5.0, self.lease))
+        json_body.update(
             {
                 "input_id": self.input_id,
                 "x": x,
@@ -497,29 +497,29 @@ class PointerSession:
                 "pointer_lease": self.lease,
             }
         )
-        self.receipt = InputReceipt(self._bridge._request("POST", "/input/pointer/move", json_body=params))
+        self.receipt = InputReceipt(self._bridge._request("POST", "/input/pointer/move", json_body=json_body))
         return self.receipt
 
     def hold(self, duration: float) -> InputReceipt:
         """Keep the pointer down at its current position for `duration`."""
         self._ensure_open()
-        params = self._bridge._input_params(lease=max(5.0, self.lease))
-        params.update(
+        json_body = self._bridge._input_json_body(lease=max(5.0, self.lease))
+        json_body.update(
             {
                 "input_id": self.input_id,
                 "duration": duration,
                 "pointer_lease": self.lease,
             }
         )
-        self.receipt = InputReceipt(self._bridge._request("POST", "/input/pointer/hold", json_body=params))
+        self.receipt = InputReceipt(self._bridge._request("POST", "/input/pointer/hold", json_body=json_body))
         return self.receipt
 
     def up(self, wait: Union[str, bool] = "released", timeout: float = 10.0) -> InputReceipt:
         """Request one final up event and optionally wait for native release injection."""
         self._ensure_open()
-        params = self._bridge._input_params(lease=max(5.0, self.lease))
-        params.update({"input_id": self.input_id, "pointer_lease": self.lease})
-        self.receipt = InputReceipt(self._bridge._request("POST", "/input/pointer/up", json_body=params))
+        json_body = self._bridge._input_json_body(lease=max(5.0, self.lease))
+        json_body.update({"input_id": self.input_id, "pointer_lease": self.lease})
+        self.receipt = InputReceipt(self._bridge._request("POST", "/input/pointer/up", json_body=json_body))
         self.closed = True
         if wait:
             target_state = "released" if wait is True else str(wait)
@@ -942,10 +942,23 @@ class Client:
         path: str,
         *,
         params: Optional[Mapping[str, Any]] = None,
+        json_body: Optional[Mapping[str, Any]] = None,
         json: Optional[Mapping[str, Any]] = None,
     ) -> JsonDict:
-        """Call a raw Automation Bridge path and return its ``data`` object."""
-        return self._request(method.upper(), path, params, json_body=json)
+        """Call a raw Automation Bridge path and return its ``data`` object.
+
+        ``params`` are encoded into the URL. Use ``json_body`` for ``POST`` and
+        ``PUT`` payloads so they are not constrained by Defold's request-resource
+        limit. ``json`` is retained as a compatibility alias for ``json_body``.
+        """
+        if json_body is not None and json is not None:
+            raise ValueError("request accepts either json_body or its json compatibility alias, not both")
+        return self._request(
+            method.upper(),
+            path,
+            params,
+            json_body=json_body if json_body is not None else json,
+        )
 
     def health(self) -> JsonDict:
         """Return and validate API version, capabilities, identity, and backend data."""
@@ -1134,20 +1147,20 @@ class Client:
     ) -> InputReceipt:
         """Queue one FIFO click and optionally wait for the native release receipt."""
         if isinstance(target, Element):
-            params: Dict[str, Any] = {"id": target.id}
+            json_body: Dict[str, Any] = {"id": target.id}
             if target.logical_id:
-                params["expected_logical_id"] = target.logical_id
+                json_body["expected_logical_id"] = target.logical_id
         elif isinstance(target, str):
-            params = {"id": target}
+            json_body = {"id": target}
         else:
             x_value, y_value = self._point(target, y)
-            params = {"x": x_value, "y": y_value}
+            json_body = {"x": x_value, "y": y_value}
 
-        params.update(self._input_params())
-        params.update({"visualize": visualize, "device": device, "expected_scene_sequence": expected_scene_sequence})
+        json_body.update(self._input_json_body())
+        json_body.update({"visualize": visualize, "device": device, "expected_scene_sequence": expected_scene_sequence})
         if pointer_id:
-            params["pointer_id"] = pointer_id
-        receipt = InputReceipt(self._request("POST", "/input/click", json_body=params))
+            json_body["pointer_id"] = pointer_id
+        receipt = InputReceipt(self._request("POST", "/input/click", json_body=json_body))
         return self._wait_input_compat(
             receipt, wait, timeout, cancel_on_interrupt, flush_on_interrupt
         )
@@ -1171,32 +1184,32 @@ class Client:
     ) -> InputReceipt:
         """Queue one FIFO drag and wait on native lifecycle state, never wall-clock guessing."""
         if self._is_element_ref(from_target) and self._is_element_ref(to_target):
-            params: Dict[str, Any] = {
+            json_body: Dict[str, Any] = {
                 "from_id": self._element_id(from_target),
                 "to_id": self._element_id(to_target),
                 "duration": duration,
             }
             if isinstance(from_target, Element) and from_target.logical_id:
-                params["expected_from_logical_id"] = from_target.logical_id
+                json_body["expected_from_logical_id"] = from_target.logical_id
             if isinstance(to_target, Element) and to_target.logical_id:
-                params["expected_to_logical_id"] = to_target.logical_id
+                json_body["expected_to_logical_id"] = to_target.logical_id
         else:
             x1, y1 = self._point(from_target)
             x2, y2 = self._point(to_target)
-            params = {"x1": x1, "y1": y1, "x2": x2, "y2": y2, "duration": duration}
+            json_body = {"x1": x1, "y1": y1, "x2": x2, "y2": y2, "duration": duration}
 
         controller_lease = min(60.0, max(5.0, duration + hold_before + hold_after + 2.0))
-        params.update(self._input_params(lease=controller_lease))
-        params.update({"visualize": visualize, "device": device, "expected_scene_sequence": expected_scene_sequence})
+        json_body.update(self._input_json_body(lease=controller_lease))
+        json_body.update({"visualize": visualize, "device": device, "expected_scene_sequence": expected_scene_sequence})
         if easing != "linear":
-            params["easing"] = easing
+            json_body["easing"] = easing
         if hold_before:
-            params["hold_before"] = hold_before
+            json_body["hold_before"] = hold_before
         if hold_after:
-            params["hold_after"] = hold_after
+            json_body["hold_after"] = hold_after
         if pointer_id:
-            params["pointer_id"] = pointer_id
-        receipt = InputReceipt(self._request("POST", "/input/drag", json_body=params))
+            json_body["pointer_id"] = pointer_id
+        receipt = InputReceipt(self._request("POST", "/input/drag", json_body=json_body))
         return self._wait_input_compat(
             receipt,
             wait,
@@ -1244,8 +1257,8 @@ class Client:
         easing_values = [easing] * expected_segments if isinstance(easing, str) else list(easing)
         if len(easing_values) != expected_segments or any(value not in _INPUT_EASINGS for value in easing_values):
             raise ValueError(f"drag_path requires {expected_segments} supported easing values")
-        params = self._input_params(lease=min(60.0, max(5.0, total_duration + 2.0)))
-        params.update(
+        json_body = self._input_json_body(lease=min(60.0, max(5.0, total_duration + 2.0)))
+        json_body.update(
             {
                 "points": ";".join(f"{x},{y}" for x, y in normalized_points),
                 "durations": ",".join(str(value) for value in duration_values),
@@ -1259,7 +1272,7 @@ class Client:
                 "expected_scene_sequence": expected_scene_sequence,
             }
         )
-        receipt = InputReceipt(self._request("POST", "/input/drag_path", json_body=params))
+        receipt = InputReceipt(self._request("POST", "/input/drag_path", json_body=json_body))
         return self._wait_input_compat(
             receipt,
             wait,
@@ -1282,8 +1295,8 @@ class Client:
         if lease <= 0:
             raise ValueError("lease must be greater than zero")
         x, y = self._point(start)
-        params = self._input_params(lease=max(5.0, lease))
-        params.update(
+        json_body = self._input_json_body(lease=max(5.0, lease))
+        json_body.update(
             {
                 "x": x,
                 "y": y,
@@ -1294,7 +1307,7 @@ class Client:
                 "expected_scene_sequence": expected_scene_sequence,
             }
         )
-        receipt = InputReceipt(self._request("POST", "/input/pointer/open", json_body=params))
+        receipt = InputReceipt(self._request("POST", "/input/pointer/open", json_body=json_body))
         return PointerSession(self, receipt, lease)
 
     def type_text(
@@ -1307,9 +1320,9 @@ class Client:
         flush_on_interrupt: bool = False,
     ) -> InputReceipt:
         """Queue FIFO text input and optionally wait for native completion."""
-        params = self._input_params()
-        params.update({"text": text, "expected_scene_sequence": expected_scene_sequence})
-        receipt = InputReceipt(self._request("POST", "/input/key", json_body=params))
+        json_body = self._input_json_body()
+        json_body.update({"text": text, "expected_scene_sequence": expected_scene_sequence})
+        receipt = InputReceipt(self._request("POST", "/input/key", json_body=json_body))
         return self._wait_input_compat(
             receipt, wait, timeout, cancel_on_interrupt, flush_on_interrupt
         )
@@ -1325,9 +1338,9 @@ class Client:
     ) -> InputReceipt:
         """Queue one FIFO special key, accepting names such as ``M``, ``SPACE``, or ``KEY_ENTER``."""
         keys = f"{{{self._normalize_key(key)}}}"
-        params = self._input_params()
-        params.update({"keys": keys, "expected_scene_sequence": expected_scene_sequence})
-        receipt = InputReceipt(self._request("POST", "/input/key", json_body=params))
+        json_body = self._input_json_body()
+        json_body.update({"keys": keys, "expected_scene_sequence": expected_scene_sequence})
+        receipt = InputReceipt(self._request("POST", "/input/key", json_body=json_body))
         return self._wait_input_compat(
             receipt, wait, timeout, cancel_on_interrupt, flush_on_interrupt
         )
@@ -1426,8 +1439,13 @@ class Client:
         if len(payload.encode("utf-8")) > 32768:
             raise ValueError("command JSON payload exceeds 32768 bytes")
         return self._request(
-            "POST", "/commands",
-            {"name": name, "data": payload, "timeout_ms": max(1, int(timeout * 1000))},
+            "POST",
+            "/commands",
+            json_body={
+                "name": name,
+                "data": payload,
+                "timeout_ms": max(1, int(timeout * 1000)),
+            },
         )
 
     def command_status(self, command_id: int) -> JsonDict:
@@ -1479,8 +1497,13 @@ class Client:
         if recording_timestamp_us is None:
             recording_timestamp_us = time.monotonic_ns() // 1000
         return self._request(
-            "POST", "/markers",
-            {"name": name, "data": payload, "recording_timestamp_us": int(recording_timestamp_us)},
+            "POST",
+            "/markers",
+            json_body={
+                "name": name,
+                "data": payload,
+                "recording_timestamp_us": int(recording_timestamp_us),
+            },
         )
 
     def screenshot(
@@ -2157,16 +2180,16 @@ class Client:
         self._remember_scene_sequence(data)
         return data
 
-    def _input_params(self, lease: float = 5.0) -> Dict[str, Any]:
+    def _input_json_body(self, lease: float = 5.0) -> Dict[str, Any]:
         """Return ownership and per-request correlation fields for mutating input calls."""
-        params: Dict[str, Any] = {
+        json_body: Dict[str, Any] = {
             "client_id": self.client_id,
             "session_id": self.session_id,
             "request_id": f"r-{uuid.uuid4().hex[:12]}",
         }
         if lease != 5.0:
-            params["lease"] = lease
-        return params
+            json_body["lease"] = lease
+        return json_body
 
     def _wait_input_compat(
         self,

--- a/automation_bridge/automation-bridge-python/automation_bridge/metal.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/metal.py
@@ -83,7 +83,7 @@ class MetalCaptureClient:
             self.bridge.request(
                 "POST",
                 "/metal",
-                params={"path": str(output), "frames": frames},
+                json_body={"path": str(output), "frames": frames},
             )
         )
         self.bridge._trace_record("metal_capture_started", capture.to_dict())

--- a/automation_bridge/automation-bridge-python/automation_bridge/recording.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/recording.py
@@ -124,9 +124,9 @@ class VideoRecordingClient:
             raise ValueError("fps must be an integer between 1 and 60")
         if audio is not None and not isinstance(audio, bool):
             raise TypeError("audio must be a boolean or None")
-        params: Dict[str, Any] = {"fps": fps}
+        json_body: Dict[str, Any] = {"fps": fps}
         if audio is not None:
-            params["audio"] = audio
+            json_body["audio"] = audio
         if size is not None:
             if (
                 not isinstance(size, tuple)
@@ -135,12 +135,12 @@ class VideoRecordingClient:
                 or any(value < 1 or value > 16384 for value in size)
             ):
                 raise ValueError("size must be a (width, height) tuple with values between 1 and 16384")
-            params.update({"width": size[0], "height": size[1]})
+            json_body.update({"width": size[0], "height": size[1]})
 
         output = Path(path).expanduser().resolve()
         output.parent.mkdir(parents=True, exist_ok=True)
-        params["path"] = str(output)
-        raw = self.bridge.request("POST", "/recording/start", json=params)
+        json_body["path"] = str(output)
+        raw = self.bridge.request("POST", "/recording/start", json_body=json_body)
         metadata = VideoRecordingMetadata.from_raw(raw)
         self.bridge._trace_record("video_recording_started", metadata.to_dict())
         return VideoRecordingSession(self, metadata)

--- a/automation_bridge/automation-bridge-python/automation_bridge/trace.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/trace.py
@@ -260,11 +260,16 @@ class TraceSession:
             if method != "POST" or not isinstance(path_value, str) or not path_value.startswith("/input/"):
                 continue
             try:
+                params = payload.get("params")
+                json_body = payload.get("json_body")
+                if json_body is None:
+                    json_body = params
+                    params = None
                 client.request(
                     "POST",
                     path_value,
-                    params=payload.get("params"),
-                    json=payload.get("json_body"),
+                    params=params,
+                    json_body=json_body,
                 )
                 replayed += 1
             except BaseException as error:

--- a/automation_bridge/src/automation_bridge_defold_private_api.cpp
+++ b/automation_bridge/src/automation_bridge_defold_private_api.cpp
@@ -36,6 +36,7 @@ namespace dmRender
     typedef uint32_t HRenderCamera;
 
     struct FrustumOptions;
+    const dmVMath::Matrix4& GetViewProjectionMatrix(HRenderContext render_context);
     void RenderListBegin(HRenderContext render_context);
     void RenderListEnd(HRenderContext render_context);
     void SetViewMatrix(HRenderContext render_context, const dmVMath::Matrix4& view);
@@ -143,28 +144,46 @@ namespace dmAutomationBridge
                    IsCloseDimension(actual_height, height, tolerance);
         }
 
-        static bool ScreenToDebugWorld(float x, float y, dmVMath::Point3* out)
+        static bool ScreenToDebugWorld(const dmVMath::Matrix4& inverse_view_projection, uint32_t window_width, uint32_t window_height, float x, float y, dmVMath::Point3* out)
         {
-            if (!g_AutomationBridge.m_GraphicsContext)
+            if (window_width == 0 || window_height == 0)
             {
                 return false;
             }
 
-            uint32_t window_height = dmGraphics::GetWindowHeight(g_AutomationBridge.m_GraphicsContext);
-            if (window_height == 0)
+            // HID coordinates address framebuffer pixels from the top-left. Aim
+            // at the center of the exact pixel delivered to HID, then unproject
+            // through the matrix DrawDebug3d will actually use. This also makes
+            // the overlay independent of a render camera left active by the
+            // user's render script.
+            float ndc_x = 2.0f * ((x + 0.5f) / (float)window_width) - 1.0f;
+            float ndc_y = 1.0f - 2.0f * ((y + 0.5f) / (float)window_height);
+            dmVMath::Vector4 world = inverse_view_projection * dmVMath::Vector4(ndc_x, ndc_y, 0.0f, 1.0f);
+            float w = world.getW();
+            if (!IsFiniteFloat(w) || fabsf(w) < 0.000001f)
             {
                 return false;
             }
 
-            *out = dmVMath::Point3(x, (float)window_height - y, 0.0f);
+            float inverse_w = 1.0f / w;
+            float world_x = world.getX() * inverse_w;
+            float world_y = world.getY() * inverse_w;
+            float world_z = world.getZ() * inverse_w;
+            if (!IsFiniteFloat(world_x) || !IsFiniteFloat(world_y) || !IsFiniteFloat(world_z))
+            {
+                return false;
+            }
+
+            *out = dmVMath::Point3(world_x, world_y, world_z);
             return true;
         }
 
-        static void DrawDebugLine(dmRender::HRenderContext render_context, float x1, float y1, float x2, float y2, const dmVMath::Vector4& color)
+        static void DrawDebugLine(dmRender::HRenderContext render_context, const dmVMath::Matrix4& inverse_view_projection, uint32_t window_width, uint32_t window_height, float x1, float y1, float x2, float y2, const dmVMath::Vector4& color)
         {
             dmVMath::Point3 start;
             dmVMath::Point3 end;
-            if (!ScreenToDebugWorld(x1, y1, &start) || !ScreenToDebugWorld(x2, y2, &end))
+            if (!ScreenToDebugWorld(inverse_view_projection, window_width, window_height, x1, y1, &start) ||
+                !ScreenToDebugWorld(inverse_view_projection, window_width, window_height, x2, y2, &end))
             {
                 return;
             }
@@ -172,7 +191,7 @@ namespace dmAutomationBridge
             dmRender::Line3D(render_context, start, end, color, color);
         }
 
-        static void DrawDebugCircle(dmRender::HRenderContext render_context, float x, float y, float radius, const dmVMath::Vector4& color)
+        static void DrawDebugCircle(dmRender::HRenderContext render_context, const dmVMath::Matrix4& inverse_view_projection, uint32_t window_width, uint32_t window_height, float x, float y, float radius, const dmVMath::Vector4& color)
         {
             static const uint32_t SEGMENTS = 32;
             static const float TAU = 6.28318530717958647692f;
@@ -184,7 +203,8 @@ namespace dmAutomationBridge
                 float angle = ((float)i / (float)SEGMENTS) * TAU;
                 float next_x = x + cosf(angle) * radius;
                 float next_y = y + sinf(angle) * radius;
-                DrawDebugLine(render_context, previous_x, previous_y, next_x, next_y, color);
+                DrawDebugLine(render_context, inverse_view_projection, window_width, window_height,
+                              previous_x, previous_y, next_x, next_y, color);
                 previous_x = next_x;
                 previous_y = next_y;
             }
@@ -342,30 +362,44 @@ namespace dmAutomationBridge
             return dmGraphics::GetWindow(g_AutomationBridge.m_GraphicsContext);
         }
 
+        static void SetGraphicsStateEnabled(dmGraphics::HContext graphics_context, dmGraphics::State state, bool enabled)
+        {
+            if (enabled)
+            {
+                dmGraphics::EnableState(graphics_context, state);
+            }
+            else
+            {
+                dmGraphics::DisableState(graphics_context, state);
+            }
+        }
+
         static void RestoreInputVisualizationGraphicsState(dmGraphics::HContext graphics_context, const dmGraphics::PipelineState& previous_state, int32_t viewport_x, int32_t viewport_y, uint32_t viewport_width, uint32_t viewport_height)
         {
-            if (previous_state.m_BlendEnabled)
-            {
-                dmGraphics::EnableState(graphics_context, dmGraphics::STATE_BLEND);
-            }
-            else
-            {
-                dmGraphics::DisableState(graphics_context, dmGraphics::STATE_BLEND);
-            }
+            SetGraphicsStateEnabled(graphics_context, dmGraphics::STATE_BLEND, previous_state.m_BlendEnabled);
+            SetGraphicsStateEnabled(graphics_context, dmGraphics::STATE_DEPTH_TEST, previous_state.m_DepthTestEnabled);
+            SetGraphicsStateEnabled(graphics_context, dmGraphics::STATE_STENCIL_TEST, previous_state.m_StencilEnabled);
+            SetGraphicsStateEnabled(graphics_context, dmGraphics::STATE_SCISSOR_TEST, previous_state.m_ScissorTestEnabled);
+            SetGraphicsStateEnabled(graphics_context, dmGraphics::STATE_CULL_FACE, previous_state.m_CullFaceEnabled);
+            SetGraphicsStateEnabled(graphics_context, dmGraphics::STATE_POLYGON_OFFSET_FILL, previous_state.m_PolygonOffsetFillEnabled);
 
-            if (previous_state.m_DepthTestEnabled)
-            {
-                dmGraphics::EnableState(graphics_context, dmGraphics::STATE_DEPTH_TEST);
-            }
-            else
-            {
-                dmGraphics::DisableState(graphics_context, dmGraphics::STATE_DEPTH_TEST);
-            }
-
-            dmGraphics::SetBlendFunc(
+            dmGraphics::SetBlendFuncSeparate(
                 graphics_context,
                 (dmGraphics::BlendFactor)previous_state.m_BlendSrcFactor,
-                (dmGraphics::BlendFactor)previous_state.m_BlendDstFactor);
+                (dmGraphics::BlendFactor)previous_state.m_BlendDstFactor,
+                (dmGraphics::BlendFactor)previous_state.m_BlendSrcFactorAlpha,
+                (dmGraphics::BlendFactor)previous_state.m_BlendDstFactorAlpha);
+            dmGraphics::SetBlendEquationSeparate(
+                graphics_context,
+                (dmGraphics::BlendEquation)previous_state.m_BlendEquationColor,
+                (dmGraphics::BlendEquation)previous_state.m_BlendEquationAlpha);
+            dmGraphics::SetDepthMask(graphics_context, previous_state.m_WriteDepth);
+            dmGraphics::SetColorMask(
+                graphics_context,
+                (previous_state.m_WriteColorMask & (1 << 3)) != 0,
+                (previous_state.m_WriteColorMask & (1 << 2)) != 0,
+                (previous_state.m_WriteColorMask & (1 << 1)) != 0,
+                (previous_state.m_WriteColorMask & (1 << 0)) != 0);
             dmGraphics::SetViewport(graphics_context, viewport_x, viewport_y, viewport_width, viewport_height);
         }
 
@@ -374,13 +408,43 @@ namespace dmAutomationBridge
             dmGraphics::SetViewport(graphics_context, 0, 0, window_width, window_height);
             dmGraphics::EnableState(graphics_context, dmGraphics::STATE_BLEND);
             dmGraphics::DisableState(graphics_context, dmGraphics::STATE_DEPTH_TEST);
-            dmGraphics::SetBlendFunc(
+            dmGraphics::DisableState(graphics_context, dmGraphics::STATE_STENCIL_TEST);
+            dmGraphics::DisableState(graphics_context, dmGraphics::STATE_SCISSOR_TEST);
+            dmGraphics::DisableState(graphics_context, dmGraphics::STATE_CULL_FACE);
+            dmGraphics::DisableState(graphics_context, dmGraphics::STATE_POLYGON_OFFSET_FILL);
+            dmGraphics::SetColorMask(graphics_context, true, true, true, true);
+            dmGraphics::SetDepthMask(graphics_context, false);
+            dmGraphics::SetBlendFuncSeparate(
                 graphics_context,
                 dmGraphics::BLEND_FACTOR_SRC_ALPHA,
+                dmGraphics::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+                dmGraphics::BLEND_FACTOR_ONE,
                 dmGraphics::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA);
+            dmGraphics::SetBlendEquationSeparate(
+                graphics_context,
+                dmGraphics::BLEND_EQUATION_ADD,
+                dmGraphics::BLEND_EQUATION_ADD);
 
             dmRender::SetViewMatrix(render_context, dmVMath::Matrix4::identity());
             dmRender::SetProjectionMatrix(render_context, dmVMath::Matrix4::orthographic(0.0f, (float)window_width, 0.0f, (float)window_height, 1.0f, -1.0f));
+        }
+
+        static bool ResolveInputVisualizationMatrix(dmRender::HRenderContext render_context, dmVMath::Matrix4* inverse_view_projection)
+        {
+            // DrawRenderList reapplies m_CurrentRenderCamera after explicit
+            // view/projection setup. An empty debug pass resolves that state
+            // without drawing, so the real pass can use matching screen points.
+            dmRender::RenderListBegin(render_context);
+            dmRender::RenderListEnd(render_context);
+            dmRender::Result result = dmRender::DrawDebug3d(render_context, 0);
+            dmRender::ClearRenderObjects(render_context);
+            if (result != dmRender::RESULT_OK)
+            {
+                return false;
+            }
+
+            *inverse_view_projection = dmVMath::Inverse(dmRender::GetViewProjectionMatrix(render_context));
+            return true;
         }
     }
 
@@ -484,28 +548,48 @@ namespace dmAutomationBridge
         float t = ClampFloat(visualization->m_Age / duration, 0.0f, 1.0f);
         float alpha = 1.0f - t;
         dmRender::HRenderContext render_context = (dmRender::HRenderContext)g_AutomationBridge.m_RenderContext;
+        dmVMath::Matrix4 previous_view = dmRender::GetViewMatrix(render_context);
+        dmVMath::Matrix4 previous_view_projection = dmRender::GetViewProjectionMatrix(render_context);
+        dmVMath::Matrix4 previous_projection = previous_view_projection * dmVMath::Inverse(previous_view);
 
-        dmRender::RenderListBegin(render_context);
+        // The visualization is a final screen overlay. Always bind the
+        // backbuffer in case the render script left an offscreen target active.
+        dmGraphics::SetRenderTarget(g_AutomationBridge.m_GraphicsContext, 0, 0);
         PrepareInputVisualizationRenderState(g_AutomationBridge.m_GraphicsContext, render_context, window_width, window_height);
 
+        dmVMath::Matrix4 inverse_view_projection;
+        if (!ResolveInputVisualizationMatrix(render_context, &inverse_view_projection))
+        {
+            dmRender::SetViewMatrix(render_context, previous_view);
+            dmRender::SetProjectionMatrix(render_context, previous_projection);
+            RestoreInputVisualizationGraphicsState(g_AutomationBridge.m_GraphicsContext, previous_state, previous_viewport_x, previous_viewport_y, previous_viewport_width, previous_viewport_height);
+            AdvanceInputVisualization(visualization);
+            return;
+        }
+
+        dmRender::RenderListBegin(render_context);
         if (visualization->m_Drag)
         {
             dmVMath::Vector4 color(1.0f, 0.72f, 0.12f, alpha);
             for (uint32_t i = 1; i < visualization->m_PointCount; ++i)
             {
-                DrawDebugLine(render_context,
+                DrawDebugLine(render_context, inverse_view_projection, window_width, window_height,
                               visualization->m_X[i - 1], visualization->m_Y[i - 1],
                               visualization->m_X[i], visualization->m_Y[i], color);
             }
             if (visualization->m_PointCount > 0)
             {
-                DrawDebugCircle(render_context, visualization->m_X[0], visualization->m_Y[0], 6.0f, color);
+                DrawDebugCircle(render_context, inverse_view_projection, window_width, window_height,
+                                visualization->m_X[0], visualization->m_Y[0], 6.0f, color);
                 uint32_t last = visualization->m_PointCount - 1;
-                DrawDebugCircle(render_context, visualization->m_X[last], visualization->m_Y[last], 6.0f, color);
+                DrawDebugCircle(render_context, inverse_view_projection, window_width, window_height,
+                                visualization->m_X[last], visualization->m_Y[last], 6.0f, color);
             }
             dmRender::RenderListEnd(render_context);
             dmRender::DrawDebug3d(render_context, 0);
             dmRender::ClearRenderObjects(render_context);
+            dmRender::SetViewMatrix(render_context, previous_view);
+            dmRender::SetProjectionMatrix(render_context, previous_projection);
             RestoreInputVisualizationGraphicsState(g_AutomationBridge.m_GraphicsContext, previous_state, previous_viewport_x, previous_viewport_y, previous_viewport_width, previous_viewport_height);
             AdvanceInputVisualization(visualization);
             return;
@@ -515,11 +599,14 @@ namespace dmAutomationBridge
         dmVMath::Vector4 color(0.15f, 0.85f, 1.0f, alpha);
         if (visualization->m_PointCount > 0)
         {
-            DrawDebugCircle(render_context, visualization->m_X[0], visualization->m_Y[0], radius, color);
+            DrawDebugCircle(render_context, inverse_view_projection, window_width, window_height,
+                            visualization->m_X[0], visualization->m_Y[0], radius, color);
         }
         dmRender::RenderListEnd(render_context);
         dmRender::DrawDebug3d(render_context, 0);
         dmRender::ClearRenderObjects(render_context);
+        dmRender::SetViewMatrix(render_context, previous_view);
+        dmRender::SetProjectionMatrix(render_context, previous_projection);
         RestoreInputVisualizationGraphicsState(g_AutomationBridge.m_GraphicsContext, previous_state, previous_viewport_x, previous_viewport_y, previous_viewport_width, previous_viewport_height);
 
         AdvanceInputVisualization(visualization);

--- a/automation_bridge/src/automation_bridge_input.cpp
+++ b/automation_bridge/src/automation_bridge_input.cpp
@@ -604,6 +604,11 @@ namespace dmAutomationBridge
     static void AddVisualizationPoint(float x, float y, bool reset)
     {
         InputVisualization* visualization = &g_AutomationBridge.m_InputVisualization;
+        // InjectPointer passes integer framebuffer coordinates to HID. Store
+        // those same coordinates so fractional request values cannot make the
+        // debug overlay differ from the event the game actually receives.
+        x = (float)(int32_t)x;
+        y = (float)(int32_t)y;
         if (reset)
         {
             memset(visualization, 0, sizeof(*visualization));

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -213,6 +213,34 @@ class EngineClientUnitTest(unittest.TestCase):
             required_capabilities=("scene", "input.drag"),
         )
 
+    def test_raw_request_uses_json_body_and_retains_json_alias(self):
+        bridge = EngineClient(1)
+        with mock.patch.object(bridge, "_request", return_value={}) as request:
+            bridge.request(
+                "post",
+                "/markers",
+                params={"query": "value"},
+                json_body={"body": "value"},
+            )
+            request.assert_called_once_with(
+                "POST",
+                "/markers",
+                {"query": "value"},
+                json_body={"body": "value"},
+            )
+
+            request.reset_mock()
+            bridge.request("post", "/markers", json={"legacy": True})
+            request.assert_called_once_with(
+                "POST",
+                "/markers",
+                None,
+                json_body={"legacy": True},
+            )
+
+        with self.assertRaisesRegex(ValueError, "either json_body.*json compatibility alias"):
+            bridge.request("POST", "/markers", json_body={}, json={})
+
     def test_event_stream_resolves_now_before_wait_and_preserves_unmatched_events(self):
         class ScriptedClient:
             timeout = 10.0
@@ -220,7 +248,7 @@ class EngineClientUnitTest(unittest.TestCase):
             def __init__(self):
                 self.requests = []
 
-            def request(self, method, path, *, params=None, json=None):
+            def request(self, method, path, *, params=None, json_body=None):
                 self.requests.append((path, params))
                 if path == "/events/cursor":
                     return {"cursor": 5, "oldest_cursor": 2}
@@ -266,7 +294,7 @@ class EngineClientUnitTest(unittest.TestCase):
         class OverflowClient:
             timeout = 10.0
 
-            def request(self, method, path, *, params=None, json=None):
+            def request(self, method, path, *, params=None, json_body=None):
                 if path == "/events/cursor":
                     return {"cursor": 20, "oldest_cursor": 10}
                 return {"events": [], "next_cursor": 10, "oldest_cursor": 10, "latest_cursor": 20, "overflow": True}
@@ -312,14 +340,14 @@ class EngineClientUnitTest(unittest.TestCase):
         self.assertEqual("status_ready", element.localization_key)
         self.assertEqual("status", element.role)
 
-    def test_command_and_marker_encode_bounded_json(self):
+    def test_command_and_marker_use_json_bodies(self):
         class ApplicationClient(EngineClient):
             def __init__(self):
                 super().__init__(12345)
                 self.requests = []
 
-            def _request(self, method, path, params=None):
-                self.requests.append((method, path, params))
+            def _request(self, method, path, params=None, json_body=None):
+                self.requests.append((method, path, params, json_body))
                 if path == "/commands":
                     return {"command_id": 9, "state": "pending"}
                 if path == "/markers":
@@ -331,10 +359,13 @@ class EngineClientUnitTest(unittest.TestCase):
         marker = bridge.mark("workflow_started", {"case": 7}, recording_timestamp_us=1234)
 
         self.assertEqual(9, accepted["command_id"])
-        self.assertEqual('{"name":"standard"}', bridge.requests[0][2]["data"])
-        self.assertEqual(2000, bridge.requests[0][2]["timeout_ms"])
+        self.assertIsNone(bridge.requests[0][2])
+        self.assertEqual('{"name":"standard"}', bridge.requests[0][3]["data"])
+        self.assertEqual(2000, bridge.requests[0][3]["timeout_ms"])
         self.assertEqual(12, marker["event_sequence"])
-        self.assertEqual(1234, bridge.requests[1][2]["recording_timestamp_us"])
+        self.assertIsNone(bridge.requests[1][2])
+        self.assertEqual('{"case":7}', bridge.requests[1][3]["data"])
+        self.assertEqual(1234, bridge.requests[1][3]["recording_timestamp_us"])
 
     def test_health_rejects_incompatible_native_api_version(self):
         bridge = FakeEngineClient()
@@ -2024,6 +2055,50 @@ class EngineClientUnitTest(unittest.TestCase):
             server.request_bytes,
         )
 
+    def test_start_command_uses_json_body_for_large_payload(self):
+        response = b'{"ok":true,"data":{"command_id":9,"state":"pending"}}'
+        command_data = {"value": "x" * 30000}
+        with FakeHttpServer(response) as server:
+            accepted = EngineClient(server.port, timeout=1.0).start_command(
+                "test.load_fixture",
+                command_data,
+                timeout=2,
+            )
+
+        self.assertEqual(9, accepted["command_id"])
+        self.assertEqual("POST /automation-bridge/v2/commands HTTP/1.1", server.request_line)
+        self.assertIn("Content-Type: application/json", server.request_text)
+        self.assertEqual(
+            {
+                "name": "test.load_fixture",
+                "data": json.dumps(command_data, separators=(",", ":")),
+                "timeout_ms": 2000,
+            },
+            json.loads(server.request_body),
+        )
+
+    def test_mark_uses_json_body_for_large_payload(self):
+        response = b'{"ok":true,"data":{"event_sequence":12}}'
+        marker_data = {"value": "x" * 30000}
+        with FakeHttpServer(response) as server:
+            marker = EngineClient(server.port, timeout=1.0).mark(
+                "workflow_started",
+                marker_data,
+                recording_timestamp_us=1234,
+            )
+
+        self.assertEqual(12, marker["event_sequence"])
+        self.assertEqual("POST /automation-bridge/v2/markers HTTP/1.1", server.request_line)
+        self.assertIn("Content-Type: application/json", server.request_text)
+        self.assertEqual(
+            {
+                "name": "workflow_started",
+                "data": json.dumps(marker_data, separators=(",", ":")),
+                "recording_timestamp_us": 1234,
+            },
+            json.loads(server.request_body),
+        )
+
     def test_screenshot_waits_for_native_complete_receipt(self):
         class ScreenshotClient(EngineClient):
             def __init__(self):
@@ -3215,7 +3290,7 @@ class AutomationBridgeApiTest(unittest.TestCase):
         self.assertEqual("key", special_key["kind"])
 
         with self.assertRaises(AutomationBridgeApiError) as unsupported_key:
-            self.bridge.request("POST", "/input/key", json={
+            self.bridge.request("POST", "/input/key", json_body={
                 "keys": "{M}",
                 "client_id": self.bridge.client_id,
                 "session_id": self.bridge.session_id,

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -3045,18 +3045,22 @@ class AutomationBridgeApiTest(unittest.TestCase):
         self.reset_if_popup_is_visible()
         screen = self.bridge.screen()
         window = screen["window"]
-        y = max(4, window["height"] - 16)
-        start = (max(4, window["width"] * 0.15), y)
-        end = (min(window["width"] - 4, window["width"] * 0.85), y)
+        requested_y = max(4, window["height"] - 16) + 0.75
+        requested_start = (max(4, window["width"] * 0.15) + 0.75, requested_y)
+        requested_end = (min(window["width"] - 4, window["width"] * 0.85) + 0.75, requested_y)
+        # Native HID receives integer framebuffer coordinates. The overlay must
+        # mark those exact coordinates, not the fractional request values.
+        start = (int(requested_start[0]), int(requested_start[1]))
+        end = (int(requested_end[0]), int(requested_end[1]))
         baseline_path = self.bridge.screenshot(wait=True, timeout=5)
-        baseline_orange = _count_orange_debug_pixels_near_segment(baseline_path, start, end)
+        baseline_orange = _count_orange_debug_pixels_near_segment(baseline_path, start, end, max_distance=3)
 
-        self.bridge.drag(start, end, duration=1.0, wait=0)
+        self.bridge.drag(requested_start, requested_end, duration=1.0, wait=0, visualize=True)
         last_observation = {"path": None, "orange_pixels": 0, "baseline_path": baseline_path, "baseline_orange": baseline_orange}
 
         def visible_overlay():
             screenshot_path = self.bridge.screenshot(wait=True, timeout=5)
-            orange_pixels = _count_orange_debug_pixels_near_segment(screenshot_path, start, end)
+            orange_pixels = _count_orange_debug_pixels_near_segment(screenshot_path, start, end, max_distance=3)
             last_observation["path"] = screenshot_path
             last_observation["orange_pixels"] = orange_pixels
             print(
@@ -3075,6 +3079,27 @@ class AutomationBridgeApiTest(unittest.TestCase):
             self.assertGreater(orange_pixels, max(20, baseline_orange + 20))
         finally:
             time.sleep(1.0)
+
+    def test_drag_without_visualization_has_no_debug_overlay(self):
+        self.ensure_running_bridge()
+        self.reset_if_popup_is_visible()
+        time.sleep(1.05)
+        screen = self.bridge.screen()
+        window = screen["window"]
+        y = max(4, window["height"] - 32)
+        start = (max(4, window["width"] * 0.2), y)
+        end = (min(window["width"] - 4, window["width"] * 0.8), y)
+        baseline_path = self.bridge.screenshot(wait=True, timeout=5)
+        baseline_orange = _count_orange_debug_pixels_near_segment(baseline_path, start, end, max_distance=3)
+
+        self.bridge.drag(start, end, duration=0.4, wait=0, visualize=False)
+        observed = []
+        for _ in range(3):
+            screenshot_path = self.bridge.screenshot(wait=True, timeout=5)
+            observed.append(_count_orange_debug_pixels_near_segment(screenshot_path, start, end, max_distance=3))
+            time.sleep(0.05)
+
+        self.assertLessEqual(max(observed), baseline_orange + 5, (baseline_path, baseline_orange, observed))
 
     def test_screenshot_rows_match_top_left_scene_bounds(self):
         self.ensure_running_bridge()

--- a/tests/test_tooling.py
+++ b/tests/test_tooling.py
@@ -248,8 +248,8 @@ class VideoRecordingTest(unittest.TestCase):
             self.traces = []
             self.fail_stop = fail_stop
 
-        def request(self, method, path, *, params=None, json=None):
-            self.requests.append((method, path, json))
+        def request(self, method, path, *, params=None, json_body=None):
+            self.requests.append((method, path, json_body))
             if path == "/recording/capabilities":
                 return {"backend": "screen_capture_kit", "available": True,
                         "application_window": True, "application_audio": True,
@@ -257,9 +257,9 @@ class VideoRecordingTest(unittest.TestCase):
                         "containers": ["mp4"], "video_codecs": ["h264"],
                         "minimum_platform_version": "macOS 15.0"}
             if path == "/recording/start":
-                return {"path": json["path"], "active": True, "finalized": False,
-                        "audio": json.get("audio", True), "width": json.get("width", 800),
-                        "height": json.get("height", 600), "fps": json["fps"]}
+                return {"path": json_body["path"], "active": True, "finalized": False,
+                        "audio": json_body.get("audio", True), "width": json_body.get("width", 800),
+                        "height": json_body.get("height", 600), "fps": json_body["fps"]}
             if path == "/recording/stop":
                 if self.fail_stop:
                     raise RuntimeError("native finalization failed")
@@ -313,13 +313,14 @@ class MetalCaptureTest(unittest.TestCase):
             self.traces = []
             self.states = list(states or [])
 
-        def request(self, method, path, *, params=None, json=None):
-            self.requests.append((method, path, params))
+        def request(self, method, path, *, params=None, json_body=None):
+            self.requests.append((method, path, params, json_body))
+            request_data = json_body if json_body is not None else params
             if method == "POST":
                 return {
                     "state": "pending",
-                    "path": params["path"],
-                    "frames": params["frames"],
+                    "path": request_data["path"],
+                    "frames": request_data["frames"],
                     "frames_captured": 0,
                     "stop_requested": False,
                 }
@@ -356,8 +357,9 @@ class MetalCaptureTest(unittest.TestCase):
         self.assertTrue(capture.complete)
         self.assertEqual(2, capture.frames_captured)
         self.assertEqual(("POST", "/metal"), bridge.requests[0][:2])
-        self.assertTrue(bridge.requests[0][2]["path"].endswith("/traces/frame.gputrace"))
-        self.assertEqual(2, bridge.requests[0][2]["frames"])
+        self.assertIsNone(bridge.requests[0][2])
+        self.assertTrue(bridge.requests[0][3]["path"].endswith("/traces/frame.gputrace"))
+        self.assertEqual(2, bridge.requests[0][3]["frames"])
         self.assertEqual(
             ["metal_capture_started", "metal_capture_finished"],
             [kind for kind, _ in bridge.traces],
@@ -402,8 +404,8 @@ class _TraceClient:
     def screenshot(self, wait=True):
         raise RuntimeError("screenshot unavailable")
 
-    def request(self, method, path, *, params=None, json=None):
-        self.posts.append((path, params, json))
+    def request(self, method, path, *, params=None, json_body=None):
+        self.posts.append((path, params, json_body))
         return {"accepted": True}
 
 
@@ -438,7 +440,7 @@ class TraceTest(unittest.TestCase):
 
             report = TraceSession.replay(client, path)
             self.assertEqual(1, report["replayed"])
-            self.assertEqual([("/input/drag", {"duration": 0.5}, None)], client.posts)
+            self.assertEqual([("/input/drag", None, {"duration": 0.5})], client.posts)
             self.assertIn("application_state", report["missing_prerequisites"])
             with self.assertRaises(TraceError):
                 TraceSession.replay(client, path, require_deterministic=True)


### PR DESCRIPTION
Python users can now send commands and other mutation payloads in JSON request bodies, avoiding Defold request-resource limits that rejected valid command payloads. Debug click and drag visuals now align with the exact injected screen coordinates, even when a game leaves custom camera, viewport, or render-target state active. No game project or render script changes are required, and debug drawing only runs when visualization is enabled.

Fix https://github.com/defold/extension-automation-bridge/issues/10

### Technical changes

- Send commands, markers, input operations, recordings, and Metal capture requests using JSON bodies instead of URL query parameters.
- Add `json_body` to the raw Python request API while retaining `json` as a compatibility alias.
- Preserve trace replay compatibility with recordings containing the previous query-parameter representation.
- Render input visualization to the backbuffer using the active debug-render view-projection matrix and exact HID pixel centers.
- Restore affected graphics state after drawing and skip the rendering path when `visualize=false`.
- Add regression coverage for large command and marker payloads, request compatibility, exact drag-overlay placement, and disabled visualization.
- Update the native and Python documentation for JSON-body requests.
- Verified with all 149 prescribed tests and an HTML5/WASM build.