### PR TITLE
Cover every named dmHID key in the special-key tables

### DIFF
--- a/automation_bridge/README.md
+++ b/automation_bridge/README.md
@@ -408,7 +408,7 @@ curl -fsS -X POST -H 'Content-Type: application/json' \
 
 ### `POST /automation-bridge/v2/input/key`
 
-Use `text` for literal UTF-8 or `keys` for a brace-wrapped special key such as URL-encoded `%7BKEY_ENTER%7D`. Values are limited to 4096 bytes. Supported names include arrows, modifiers, navigation keys, `KEY_F1`–`KEY_F12`, `KEY_A`–`KEY_Z`, and `KEY_0`–`KEY_9`. Unknown or malformed brace-wrapped names return `unsupported_key` instead of producing a successful no-op receipt. Braces supplied through `text` remain literal. Key presses share the FIFO, report the same receipts, and cancellation releases an active special key.
+Use `text` for literal UTF-8 or `keys` for a brace-wrapped special key such as URL-encoded `%7BKEY_ENTER%7D`. Values are limited to 4096 bytes. Supported names cover every named key in the engine's `dmHID::Key` enum: arrows, modifiers, navigation keys, `KEY_F1`–`KEY_F12`, `KEY_A`–`KEY_Z`, `KEY_0`–`KEY_9`, punctuation and symbol keys (`KEY_EQUALS`, `KEY_MINUS`, `KEY_COMMA`, `KEY_PERIOD`, `KEY_SLASH`, brackets, and the rest), keypad keys (`KEY_KP_0`–`KEY_KP_9`, `KEY_KP_ADD`, ...), and lock/system keys (`KEY_CAPS_LOCK`, `KEY_PAUSE`, `KEY_LSUPER`, ...). Unknown or malformed brace-wrapped names return `unsupported_key` instead of producing a successful no-op receipt. Braces supplied through `text` remain literal. Key presses share the FIFO, report the same receipts, and cancellation releases an active special key.
 
 ### `GET /automation-bridge/v2/screenshot`
 

--- a/automation_bridge/automation-bridge-python/automation_bridge/client.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/client.py
@@ -33,11 +33,25 @@ _NAMED_KEYS = {
     "BACKSPACE", "INSERT", "DEL", "DELETE", "PAGEUP", "PAGEDOWN", "HOME", "END",
     "LSHIFT", "RSHIFT", "LCTRL", "RCTRL", "LALT", "RALT",
     *(f"F{number}" for number in range(1, 13)),
+    # Punctuation and symbol keys -- every remaining named key in dmHID's Key enum.
+    "EXCLAIM", "QUOTEDBL", "HASH", "DOLLAR", "AMPERSAND", "QUOTE", "LPAREN",
+    "RPAREN", "ASTERISK", "PLUS", "COMMA", "MINUS", "PERIOD", "SLASH", "COLON",
+    "SEMICOLON", "LESS", "EQUALS", "GREATER", "QUESTION", "AT", "LBRACKET",
+    "BACKSLASH", "RBRACKET", "CARET", "UNDERSCORE", "BACKQUOTE", "LBRACE",
+    "PIPE", "RBRACE", "TILDE",
+    # Keypad
+    *(f"KP_{number}" for number in range(10)),
+    "KP_DIVIDE", "KP_MULTIPLY", "KP_SUBTRACT", "KP_ADD", "KP_DECIMAL",
+    "KP_EQUAL", "KP_ENTER", "KP_NUM_LOCK",
+    # Lock/system keys
+    "CAPS_LOCK", "SCROLL_LOCK", "PAUSE", "LSUPER", "RSUPER", "MENU", "BACK",
 }
 _KEY_ERROR = (
-    "key must be A-Z, 0-9, F1-F12, or one of SPACE, ESCAPE, UP, DOWN, LEFT, "
-    "RIGHT, TAB, ENTER, BACKSPACE, INSERT, DELETE, PAGEUP, PAGEDOWN, HOME, END, "
-    "LSHIFT, RSHIFT, LCTRL, RCTRL, LALT, or RALT; an optional KEY_ prefix is accepted"
+    "key must be A-Z, 0-9, F1-F12, a named key from the engine's dmHID Key enum "
+    "(SPACE, ESCAPE, arrows, TAB, ENTER, BACKSPACE, navigation keys, modifiers, "
+    "punctuation/symbol keys such as EQUALS, MINUS, COMMA, PERIOD, SLASH, "
+    "keypad keys such as KP_0-KP_9 and KP_ADD, or lock/system keys such as "
+    "CAPS_LOCK, PAUSE, LSUPER); an optional KEY_ prefix is accepted"
 )
 PYTHON_PACKAGE_VERSION = "3.0.0"
 SUPPORTED_API_VERSION_MIN = 2

--- a/automation_bridge/src/automation_bridge_input.cpp
+++ b/automation_bridge/src/automation_bridge_input.cpp
@@ -510,7 +510,40 @@ namespace dmAutomationBridge
             {"KEY_F1", dmHID::KEY_F1}, {"KEY_F2", dmHID::KEY_F2}, {"KEY_F3", dmHID::KEY_F3},
             {"KEY_F4", dmHID::KEY_F4}, {"KEY_F5", dmHID::KEY_F5}, {"KEY_F6", dmHID::KEY_F6},
             {"KEY_F7", dmHID::KEY_F7}, {"KEY_F8", dmHID::KEY_F8}, {"KEY_F9", dmHID::KEY_F9},
-            {"KEY_F10", dmHID::KEY_F10}, {"KEY_F11", dmHID::KEY_F11}, {"KEY_F12", dmHID::KEY_F12}
+            {"KEY_F10", dmHID::KEY_F10}, {"KEY_F11", dmHID::KEY_F11}, {"KEY_F12", dmHID::KEY_F12},
+            // Punctuation and symbol keys -- every remaining named key in dmHID's Key enum,
+            // so any key_trigger a game.input_binding can express is reachable by name.
+            {"KEY_EXCLAIM", dmHID::KEY_EXCLAIM}, {"KEY_QUOTEDBL", dmHID::KEY_QUOTEDBL},
+            {"KEY_HASH", dmHID::KEY_HASH}, {"KEY_DOLLAR", dmHID::KEY_DOLLAR},
+            {"KEY_AMPERSAND", dmHID::KEY_AMPERSAND}, {"KEY_QUOTE", dmHID::KEY_QUOTE},
+            {"KEY_LPAREN", dmHID::KEY_LPAREN}, {"KEY_RPAREN", dmHID::KEY_RPAREN},
+            {"KEY_ASTERISK", dmHID::KEY_ASTERISK}, {"KEY_PLUS", dmHID::KEY_PLUS},
+            {"KEY_COMMA", dmHID::KEY_COMMA}, {"KEY_MINUS", dmHID::KEY_MINUS},
+            {"KEY_PERIOD", dmHID::KEY_PERIOD}, {"KEY_SLASH", dmHID::KEY_SLASH},
+            {"KEY_COLON", dmHID::KEY_COLON}, {"KEY_SEMICOLON", dmHID::KEY_SEMICOLON},
+            {"KEY_LESS", dmHID::KEY_LESS}, {"KEY_EQUALS", dmHID::KEY_EQUALS},
+            {"KEY_GREATER", dmHID::KEY_GREATER}, {"KEY_QUESTION", dmHID::KEY_QUESTION},
+            {"KEY_AT", dmHID::KEY_AT}, {"KEY_LBRACKET", dmHID::KEY_LBRACKET},
+            {"KEY_BACKSLASH", dmHID::KEY_BACKSLASH}, {"KEY_RBRACKET", dmHID::KEY_RBRACKET},
+            {"KEY_CARET", dmHID::KEY_CARET}, {"KEY_UNDERSCORE", dmHID::KEY_UNDERSCORE},
+            {"KEY_BACKQUOTE", dmHID::KEY_BACKQUOTE}, {"KEY_LBRACE", dmHID::KEY_LBRACE},
+            {"KEY_PIPE", dmHID::KEY_PIPE}, {"KEY_RBRACE", dmHID::KEY_RBRACE},
+            {"KEY_TILDE", dmHID::KEY_TILDE},
+            // Keypad
+            {"KEY_KP_0", dmHID::KEY_KP_0}, {"KEY_KP_1", dmHID::KEY_KP_1},
+            {"KEY_KP_2", dmHID::KEY_KP_2}, {"KEY_KP_3", dmHID::KEY_KP_3},
+            {"KEY_KP_4", dmHID::KEY_KP_4}, {"KEY_KP_5", dmHID::KEY_KP_5},
+            {"KEY_KP_6", dmHID::KEY_KP_6}, {"KEY_KP_7", dmHID::KEY_KP_7},
+            {"KEY_KP_8", dmHID::KEY_KP_8}, {"KEY_KP_9", dmHID::KEY_KP_9},
+            {"KEY_KP_DIVIDE", dmHID::KEY_KP_DIVIDE}, {"KEY_KP_MULTIPLY", dmHID::KEY_KP_MULTIPLY},
+            {"KEY_KP_SUBTRACT", dmHID::KEY_KP_SUBTRACT}, {"KEY_KP_ADD", dmHID::KEY_KP_ADD},
+            {"KEY_KP_DECIMAL", dmHID::KEY_KP_DECIMAL}, {"KEY_KP_EQUAL", dmHID::KEY_KP_EQUAL},
+            {"KEY_KP_ENTER", dmHID::KEY_KP_ENTER}, {"KEY_KP_NUM_LOCK", dmHID::KEY_KP_NUM_LOCK},
+            // Lock/system keys
+            {"KEY_CAPS_LOCK", dmHID::KEY_CAPS_LOCK}, {"KEY_SCROLL_LOCK", dmHID::KEY_SCROLL_LOCK},
+            {"KEY_PAUSE", dmHID::KEY_PAUSE}, {"KEY_LSUPER", dmHID::KEY_LSUPER},
+            {"KEY_RSUPER", dmHID::KEY_RSUPER}, {"KEY_MENU", dmHID::KEY_MENU},
+            {"KEY_BACK", dmHID::KEY_BACK}
         };
         for (uint32_t i = 0; i < DM_ARRAY_SIZE(keys); ++i)
         {
@@ -562,7 +595,7 @@ namespace dmAutomationBridge
             }
             if (KeyFromName(name) == dmHID::MAX_KEY_COUNT)
             {
-                *error = "unsupported special key; accepted names include KEY_A-KEY_Z, KEY_0-KEY_9, KEY_F1-KEY_F12, KEY_SPACE, KEY_ESCAPE, arrows, modifiers, and navigation keys";
+                *error = "unsupported special key; accepted names include KEY_A-KEY_Z, KEY_0-KEY_9, KEY_F1-KEY_F12, KEY_SPACE, KEY_ESCAPE, arrows, modifiers, navigation keys, punctuation/symbol keys (e.g. KEY_EQUALS, KEY_MINUS, KEY_COMMA), keypad keys (KEY_KP_0-KEY_KP_9 etc.), and lock/system keys";
                 return false;
             }
             index = next_index;

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -1510,11 +1510,14 @@ class EngineClientUnitTest(unittest.TestCase):
     def test_key_normalizes_common_names_and_optional_prefixes(self):
         bridge = FakeInputClient()
 
-        for key in ("M", "space", "KEY_ESCAPE", "{key_f12}", "7"):
+        for key in ("M", "space", "KEY_ESCAPE", "{key_f12}", "7", "EQUALS", "minus", "kp_0", "{KEY_CAPS_LOCK}"):
             bridge.key(key, wait=False)
 
         self.assertEqual(
-            ["{KEY_M}", "{KEY_SPACE}", "{KEY_ESCAPE}", "{KEY_F12}", "{KEY_7}"],
+            [
+                "{KEY_M}", "{KEY_SPACE}", "{KEY_ESCAPE}", "{KEY_F12}", "{KEY_7}",
+                "{KEY_EQUALS}", "{KEY_MINUS}", "{KEY_KP_0}", "{KEY_CAPS_LOCK}",
+            ],
             [request[2]["keys"] for request in bridge.api_requests],
         )
 


### PR DESCRIPTION
## Problem

`KeyFromName` only maps letters, digits, F-keys, arrows, modifiers, and navigation keys. A `game.input_binding` `key_trigger` on any punctuation, symbol, keypad, or lock/system key — `KEY_EQUALS`, `KEY_MINUS`, `KEY_KP_0`, `KEY_CAPS_LOCK`, … — is unreachable through the bridge: sending the character via `text` feeds the engine's text packet, which by design never fires key triggers, and the brace-wrapped name is rejected with `unsupported_key`. Hit in practice by an agent trying to drive a `KEY_EQUALS` binding (widen-node hotkey in a spline editor): bare `=` arrived as a text event and did nothing, and `{KEY_EQUALS}` was refused, leaving no path at all.

## Change

Adds the complete remaining set of named keys from the engine's `dmHID::Key` enum (`dmsdk/hid/hid.h`) to:

- the native `KeyFromName` table (punctuation/symbol row, keypad `KEY_KP_*`, lock/system keys),
- the Python wrapper's `_NAMED_KEYS` allowlist (so `bridge.key("EQUALS")` normalizes like the existing names),
- the `unsupported_key` error message, the endpoint README, and the wrapper's normalization test.

No behavior change for previously-valid names; previously-rejected names now inject.

## Tests

Extended `test_key_normalizes_common_names_and_optional_prefixes` with `EQUALS`, `minus`, `kp_0`, and `{KEY_CAPS_LOCK}`; full `tests.test_automation_bridge_api` suite passes (122 tests, 1 pre-existing skip).

Independent of #14 (they touch adjacent code but different hunks and merge cleanly in either order).