### PR TITLE
Add chord modifiers to input events

### DIFF
--- a/automation_bridge/AGENTS.md
+++ b/automation_bridge/AGENTS.md
@@ -20,7 +20,9 @@
   viewport, display, or GUI transforms.
 - Input is FIFO and receipt-based. Wait for the required phase. `text` is literal
   UTF-8; `keys` contains one validated brace-wrapped special key, optionally kept
-  pressed for `hold` seconds (`0..60`) before its release.
+  pressed for `hold` seconds (`0..60`) before its release. `modifiers` holds up to
+  four named keys as a chord across a click, drag, pointer session, or key press
+  (pressed one update before the primary action, released one update after).
 - Screenshot and Metal captures are asynchronous; poll their status receipts.
   Metal capture requires macOS, the Metal adapter, and
   `METAL_CAPTURE_ENABLED=1`; inspect completed traces with `gpudebug` when

--- a/automation_bridge/README.md
+++ b/automation_bridge/README.md
@@ -378,7 +378,7 @@ now belongs to a different runtime instance, the request returns HTTP 409 with
 
 ### `POST /automation-bridge/v2/input/click`
 
-Use `id`, or finite `x`/`y`. Optional common fields are `device`, `pointer_id`, `visualize`, `expected_scene_sequence`, and the ownership/correlation fields above.
+Use `id`, or finite `x`/`y`. Optional common fields are `device`, `pointer_id`, `visualize`, `expected_scene_sequence`, and the ownership/correlation fields above. `modifiers` holds up to four comma-separated key names (e.g. `modifiers=KEY_LSHIFT` for shift-click) as a chord for the whole gesture: pressed one engine update before the pointer goes down and released one update after it comes up, re-asserted every update while the event plays. Accepted names are the same as the `keys` parameter's special keys; unknown names, an empty list, or more than four return an error instead of silently tapping unmodified.
 
 ```sh
 curl -fsS -X POST "$BASE/input/click?id=e:0123456789abcdef&client_id=runner&session_id=test&request_id=click-1"
@@ -386,7 +386,7 @@ curl -fsS -X POST "$BASE/input/click?id=e:0123456789abcdef&client_id=runner&sess
 
 ### `POST /automation-bridge/v2/input/drag`
 
-Use `from_id`/`to_id`, or `x1`/`y1`/`x2`/`y2`. `duration`, `hold_before`, and `hold_after` are seconds in `0..60`; their total must not exceed 60. `easing` is `linear`, `ease_in`, `ease_out`, or `ease_in_out`.
+Use `from_id`/`to_id`, or `x1`/`y1`/`x2`/`y2`. `duration`, `hold_before`, and `hold_after` are seconds in `0..60`; their total must not exceed 60. `easing` is `linear`, `ease_in`, `ease_out`, or `ease_in_out`. `modifiers` works as on `/input/click` (e.g. `modifiers=KEY_LCTRL` for ctrl-drag), held across the whole down/move/up.
 
 ```sh
 curl -fsS -X POST "$BASE/input/drag?x1=100&y1=100&x2=500&y2=300&duration=.35&easing=ease_in_out&client_id=runner&session_id=test"
@@ -394,7 +394,7 @@ curl -fsS -X POST "$BASE/input/drag?x1=100&y1=100&x2=500&y2=300&duration=.35&eas
 
 ### `POST /automation-bridge/v2/input/drag_path`
 
-Runs exactly one down, a continuous native path, and one up. `points` contains `x,y` pairs separated by semicolons. For `path=sampled` or `linear`, `durations` and `easing` have one comma-separated value per segment. `path=quadratic` requires three control points and one duration/easing; `path=cubic` requires four. Paths contain 2–128 points, the encoded point list is limited to 8192 bytes, and total duration including holds is at most 60 seconds. Visualization records and draws positions actually injected on engine updates, including the sampled curve, rather than drawing only a start/end chord.
+Runs exactly one down, a continuous native path, and one up. `points` contains `x,y` pairs separated by semicolons. For `path=sampled` or `linear`, `durations` and `easing` have one comma-separated value per segment. `path=quadratic` requires three control points and one duration/easing; `path=cubic` requires four. Paths contain 2–128 points, the encoded point list is limited to 8192 bytes, and total duration including holds is at most 60 seconds. Visualization records and draws positions actually injected on engine updates, including the sampled curve, rather than drawing only a start/end chord. `modifiers` works as on `/input/click`, held across the whole gesture.
 
 ```sh
 curl -fsS -X POST -H 'Content-Type: application/json' \
@@ -404,11 +404,11 @@ curl -fsS -X POST -H 'Content-Type: application/json' \
 
 ### Low-level pointer sessions
 
-`POST /input/pointer/open?x=...&y=...&pointer_lease=2...` creates a leased pointer receipt. Append continuous work with `/input/pointer/move?input_id=...&x=...&y=...&duration=...&easing=...` and `/input/pointer/hold?input_id=...&duration=...`; finish with `/input/pointer/up?input_id=...`. Every command includes the same client/session identity and renews `pointer_lease`. If the client disappears, expiry emits a safe release/cancel. `POST /input/cancel` closes a session immediately.
+`POST /input/pointer/open?x=...&y=...&pointer_lease=2...` creates a leased pointer receipt. `modifiers` works as on `/input/click`, held for the whole session until the pointer releases. Append continuous work with `/input/pointer/move?input_id=...&x=...&y=...&duration=...&easing=...` and `/input/pointer/hold?input_id=...&duration=...`; finish with `/input/pointer/up?input_id=...`. Every command includes the same client/session identity and renews `pointer_lease`. If the client disappears, expiry emits a safe release/cancel. `POST /input/cancel` closes a session immediately.
 
 ### `POST /automation-bridge/v2/input/key`
 
-Use `text` for literal UTF-8 or `keys` for a brace-wrapped special key such as URL-encoded `%7BKEY_ENTER%7D`. Values are limited to 4096 bytes. Supported names cover every named key in the engine's `dmHID::Key` enum: arrows, modifiers, navigation keys, `KEY_F1`–`KEY_F12`, `KEY_A`–`KEY_Z`, `KEY_0`–`KEY_9`, punctuation and symbol keys (`KEY_EQUALS`, `KEY_MINUS`, `KEY_COMMA`, `KEY_PERIOD`, `KEY_SLASH`, brackets, and the rest), keypad keys (`KEY_KP_0`–`KEY_KP_9`, `KEY_KP_ADD`, ...), and lock/system keys (`KEY_CAPS_LOCK`, `KEY_PAUSE`, `KEY_LSUPER`, ...). Unknown or malformed brace-wrapped names return `unsupported_key` instead of producing a successful no-op receipt. Braces supplied through `text` remain literal. `hold` keeps each special key pressed for that many seconds (`0..60`, default `0` -- a single-update tap) before releasing it; it applies per `{KEY_...}` token, the combined hold across all tokens must stay within 60 seconds, and it requires at least one special key (literal text cannot be held). While held, the key is re-asserted every engine update, so bindings receive the same continuous per-frame actions a physically held key produces; the receipt's `requested_duration` reports the total requested hold. Key presses share the FIFO, report the same receipts, and cancellation releases an active special key.
+Use `text` for literal UTF-8 or `keys` for a brace-wrapped special key such as URL-encoded `%7BKEY_ENTER%7D`. Values are limited to 4096 bytes. Supported names cover every named key in the engine's `dmHID::Key` enum: arrows, modifiers, navigation keys, `KEY_F1`–`KEY_F12`, `KEY_A`–`KEY_Z`, `KEY_0`–`KEY_9`, punctuation and symbol keys (`KEY_EQUALS`, `KEY_MINUS`, `KEY_COMMA`, `KEY_PERIOD`, `KEY_SLASH`, brackets, and the rest), keypad keys (`KEY_KP_0`–`KEY_KP_9`, `KEY_KP_ADD`, ...), and lock/system keys (`KEY_CAPS_LOCK`, `KEY_PAUSE`, `KEY_LSUPER`, ...). Unknown or malformed brace-wrapped names return `unsupported_key` instead of producing a successful no-op receipt. Braces supplied through `text` remain literal. `hold` keeps each special key pressed for that many seconds (`0..60`, default `0` -- a single-update tap) before releasing it; it applies per `{KEY_...}` token, the combined hold across all tokens must stay within 60 seconds, and it requires at least one special key (literal text cannot be held). While held, the key is re-asserted every engine update, so bindings receive the same continuous per-frame actions a physically held key produces; the receipt's `requested_duration` reports the total requested hold. `modifiers` holds up to four comma-separated key names as a chord across the press (e.g. `keys=%7BKEY_Z%7D&modifiers=KEY_LCTRL` for ctrl-Z), pressed one update before the first key and released one update after the last; it composes with `hold` and requires at least one special key (literal text cannot be chorded). Key presses share the FIFO, report the same receipts, and cancellation releases an active special key.
 
 ### `GET /automation-bridge/v2/screenshot`
 

--- a/automation_bridge/automation-bridge-python/automation_bridge/client.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/client.py
@@ -1158,8 +1158,15 @@ class Client:
         timeout: float = 5.0,
         cancel_on_interrupt: bool = True,
         flush_on_interrupt: bool = False,
+        modifiers: Optional[Union[str, Sequence[str]]] = None,
     ) -> InputReceipt:
-        """Queue one FIFO click and optionally wait for the native release receipt."""
+        """Queue one FIFO click and optionally wait for the native release receipt.
+
+        ``modifiers`` holds up to four keys as a chord for the whole click (e.g.
+        ``"LSHIFT"`` for shift-click): pressed one update before the pointer goes
+        down and released one update after it comes up, so bindings that track the
+        modifier's own key trigger observe the same ordering a human chord produces.
+        """
         if isinstance(target, Element):
             json_body: Dict[str, Any] = {"id": target.id}
             if target.logical_id:
@@ -1174,6 +1181,9 @@ class Client:
         json_body.update({"visualize": visualize, "device": device, "expected_scene_sequence": expected_scene_sequence})
         if pointer_id:
             json_body["pointer_id"] = pointer_id
+        normalized_modifiers = self._normalize_modifiers(modifiers)
+        if normalized_modifiers is not None:
+            json_body["modifiers"] = normalized_modifiers
         receipt = InputReceipt(self._request("POST", "/input/click", json_body=json_body))
         return self._wait_input_compat(
             receipt, wait, timeout, cancel_on_interrupt, flush_on_interrupt
@@ -1195,8 +1205,14 @@ class Client:
         timeout: Optional[float] = None,
         cancel_on_interrupt: bool = True,
         flush_on_interrupt: bool = False,
+        modifiers: Optional[Union[str, Sequence[str]]] = None,
     ) -> InputReceipt:
-        """Queue one FIFO drag and wait on native lifecycle state, never wall-clock guessing."""
+        """Queue one FIFO drag and wait on native lifecycle state, never wall-clock guessing.
+
+        ``modifiers`` holds up to four keys as a chord for the whole drag (e.g.
+        ``"LCTRL"`` for ctrl-drag), pressed one update before the pointer goes down
+        and released one update after the final up.
+        """
         if self._is_element_ref(from_target) and self._is_element_ref(to_target):
             json_body: Dict[str, Any] = {
                 "from_id": self._element_id(from_target),
@@ -1223,6 +1239,9 @@ class Client:
             json_body["hold_after"] = hold_after
         if pointer_id:
             json_body["pointer_id"] = pointer_id
+        normalized_modifiers = self._normalize_modifiers(modifiers)
+        if normalized_modifiers is not None:
+            json_body["modifiers"] = normalized_modifiers
         receipt = InputReceipt(self._request("POST", "/input/drag", json_body=json_body))
         return self._wait_input_compat(
             receipt,
@@ -1248,8 +1267,13 @@ class Client:
         timeout: Optional[float] = None,
         cancel_on_interrupt: bool = True,
         flush_on_interrupt: bool = False,
+        modifiers: Optional[Union[str, Sequence[str]]] = None,
     ) -> InputReceipt:
-        """Run one down/path/up gesture with native segment timing, easing, holds, and curves."""
+        """Run one down/path/up gesture with native segment timing, easing, holds, and curves.
+
+        ``modifiers`` holds up to four keys as a chord for the whole gesture, pressed
+        one update before the pointer goes down and released one update after the up.
+        """
         normalized_points = [self._point(point) for point in points]
         if path not in {"sampled", "linear", "quadratic", "cubic"}:
             raise ValueError("path must be sampled, linear, quadratic, or cubic")
@@ -1286,6 +1310,9 @@ class Client:
                 "expected_scene_sequence": expected_scene_sequence,
             }
         )
+        normalized_modifiers = self._normalize_modifiers(modifiers)
+        if normalized_modifiers is not None:
+            json_body["modifiers"] = normalized_modifiers
         receipt = InputReceipt(self._request("POST", "/input/drag_path", json_body=json_body))
         return self._wait_input_compat(
             receipt,
@@ -1303,8 +1330,13 @@ class Client:
         device: Optional[str] = None,
         pointer_id: int = 0,
         expected_scene_sequence: Optional[int] = None,
+        modifiers: Optional[Union[str, Sequence[str]]] = None,
     ) -> PointerSession:
-        """Press a leased pointer for continuous `move`/`hold` operations and safe cleanup."""
+        """Press a leased pointer for continuous `move`/`hold` operations and safe cleanup.
+
+        ``modifiers`` holds up to four keys as a chord for the whole session, pressed
+        one update before the pointer goes down and released one update after the up.
+        """
         lease = self._input_duration(lease, "lease")
         if lease <= 0:
             raise ValueError("lease must be greater than zero")
@@ -1321,6 +1353,9 @@ class Client:
                 "expected_scene_sequence": expected_scene_sequence,
             }
         )
+        normalized_modifiers = self._normalize_modifiers(modifiers)
+        if normalized_modifiers is not None:
+            json_body["modifiers"] = normalized_modifiers
         receipt = InputReceipt(self._request("POST", "/input/pointer/open", json_body=json_body))
         return PointerSession(self, receipt, lease)
 
@@ -1350,8 +1385,13 @@ class Client:
         cancel_on_interrupt: bool = True,
         flush_on_interrupt: bool = False,
         hold: float = 0.0,
+        modifiers: Optional[Union[str, Sequence[str]]] = None,
     ) -> InputReceipt:
         """Queue one FIFO special key, accepting names such as ``M``, ``SPACE``, or ``KEY_ENTER``.
+
+        ``modifiers`` holds up to four keys as a chord across the press (e.g.
+        ``key("Z", modifiers="LCTRL")`` for ctrl-Z), pressed one update before the
+        key and released one update after it; composes with ``hold``.
 
         ``hold`` keeps the key pressed for that many seconds (``0..60``, default
         ``0`` -- a single-update tap) before releasing it, producing the same
@@ -1366,6 +1406,9 @@ class Client:
         json_body.update({"keys": keys, "expected_scene_sequence": expected_scene_sequence})
         if hold > 0.0:
             json_body["hold"] = hold
+        normalized_modifiers = self._normalize_modifiers(modifiers)
+        if normalized_modifiers is not None:
+            json_body["modifiers"] = normalized_modifiers
         receipt = InputReceipt(self._request("POST", "/input/key", json_body=json_body))
         return self._wait_input_compat(
             receipt, wait, timeout, cancel_on_interrupt, flush_on_interrupt
@@ -2267,6 +2310,18 @@ class Client:
         if (len(name) == 1 and name in "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789") or name in _NAMED_KEYS:
             return f"KEY_{name}"
         raise ValueError(_KEY_ERROR)
+
+    @classmethod
+    def _normalize_modifiers(cls, modifiers: Optional[Union[str, Sequence[str]]]) -> Optional[str]:
+        """Normalize chord modifiers into the wire format (comma-separated ``KEY_`` names)."""
+        if modifiers is None:
+            return None
+        names = [modifiers] if isinstance(modifiers, str) else list(modifiers)
+        if len(names) == 0:
+            raise ValueError("modifiers must name at least one key")
+        if len(names) > 4:
+            raise ValueError("at most 4 modifiers are supported")
+        return ",".join(cls._normalize_key(name) for name in names)
 
     def _trace_record(self, kind: str, payload: Any) -> None:
         for trace in tuple(self._active_traces):

--- a/automation_bridge/src/automation_bridge_http.cpp
+++ b/automation_bridge/src/automation_bridge_http.cpp
@@ -1476,6 +1476,24 @@ namespace dmAutomationBridge
         return true;
     }
 
+    // Parse the optional "modifiers" parameter (comma-separated key names held as a chord
+    // for the whole event). Absent is fine; supplied-but-invalid (empty, unknown name,
+    // too many) sends the error response and fails the request rather than silently
+    // degrading to an unmodified gesture.
+    static bool GetModifiersParam(RequestContext* ctx, dmHID::Key* modifiers, uint32_t* modifier_count)
+    {
+        *modifier_count = 0;
+        const char* text = RequestGetParam(ctx, "modifiers");
+        if (text == 0) return true;
+        const char* error = 0;
+        if (!ParseModifierList(text, modifiers, MAX_INPUT_MODIFIERS, modifier_count, &error))
+        {
+            RequestSendError(ctx, 400, "unsupported_key", error);
+            return false;
+        }
+        return true;
+    }
+
     static bool QueuePointerPath(RequestContext* ctx, Array<InputPoint>* points, InputPathMode mode,
                                  float hold_before, float hold_after, const char* kind, bool pointer_open, float pointer_lease)
     {
@@ -1483,6 +1501,9 @@ namespace dmAutomationBridge
         uint32_t pointer_id = 0;
         bool visualize = true;
         if (!GetInputOptions(ctx, &device, &pointer_id, &visualize)) return false;
+        dmHID::Key modifiers[MAX_INPUT_MODIFIERS];
+        uint32_t modifier_count = 0;
+        if (!GetModifiersParam(ctx, modifiers, &modifier_count)) return false;
         const char* client_id = 0;
         const char* session_id = 0;
         const char* request_id = 0;
@@ -1491,6 +1512,7 @@ namespace dmAutomationBridge
             !AcquireControllerForRequest(ctx, client_id, session_id, controller_lease)) return false;
         InputReceipt* receipt = 0;
         if (!AddMouseInput(points, mode, hold_before, hold_after, device, pointer_id, visualize, kind,
+                           modifiers, modifier_count,
                            client_id, session_id, request_id, g_AutomationBridge.m_Snapshot.m_Sequence,
                            pointer_lease, pointer_open, &receipt))
         {
@@ -1701,13 +1723,21 @@ namespace dmAutomationBridge
             RequestSendError(ctx, 400, "bad_request", "total key hold duration exceeds 60 seconds");
             return;
         }
+        dmHID::Key modifiers[MAX_INPUT_MODIFIERS];
+        uint32_t modifier_count = 0;
+        if (!GetModifiersParam(ctx, modifiers, &modifier_count)) return;
+        if (modifier_count > 0 && special_key_count == 0)
+        {
+            RequestSendError(ctx, 400, "bad_request", "modifiers require at least one {KEY_...} special key via the keys parameter; literal text cannot be chorded");
+            return;
+        }
         const char* client_id = 0;
         const char* session_id = 0;
         const char* request_id = 0;
         float lease = 5.0f;
         if (!GetInputIdentity(ctx, &client_id, &session_id, &request_id, &lease) || !AcquireControllerForRequest(ctx, client_id, session_id, lease)) return;
         InputReceipt* receipt = 0;
-        if (!AddKeyInput(value, parse_special_keys, key_hold, client_id, session_id, request_id,
+        if (!AddKeyInput(value, parse_special_keys, key_hold, modifiers, modifier_count, client_id, session_id, request_id,
                          g_AutomationBridge.m_Snapshot.m_Sequence, &receipt))
         {
             RequestSendError(ctx, 429, "input_queue_full", "too many input events are already queued");

--- a/automation_bridge/src/automation_bridge_input.cpp
+++ b/automation_bridge/src/automation_bridge_input.cpp
@@ -251,8 +251,21 @@ namespace dmAutomationBridge
         return total;
     }
 
+    // Copy validated chord modifiers into a freshly-initialized event (see the
+    // InputEvent field comment; parse/validation happens in ParseModifierList).
+    static void SetEventModifiers(InputEvent* event, const dmHID::Key* modifiers, uint32_t modifier_count)
+    {
+        uint32_t count = modifier_count > MAX_INPUT_MODIFIERS ? MAX_INPUT_MODIFIERS : modifier_count;
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            event->m_Modifiers[i] = modifiers[i];
+        }
+        event->m_ModifierCount = (uint8_t)count;
+    }
+
     bool AddMouseInput(const Array<InputPoint>* points, InputPathMode path_mode, float hold_before, float hold_after,
                        InputDevice device, uint32_t pointer_id, bool visualize, const char* kind,
+                       const dmHID::Key* modifiers, uint32_t modifier_count,
                        const char* client_id, const char* session_id, const char* request_id,
                        uint64_t scene_sequence, float lease, bool pointer_open, InputReceipt** receipt)
     {
@@ -275,6 +288,7 @@ namespace dmAutomationBridge
         event.m_MouseButton = dmHID::MOUSE_BUTTON_LEFT;
         event.m_Visualize = visualize;
         event.m_ActiveKey = dmHID::MAX_KEY_COUNT;
+        SetEventModifiers(&event, modifiers, modifier_count);
         event.m_PointerOpen = pointer_open;
         event.m_LeaseDeadline = pointer_open ? dmTime::GetTime() + (uint64_t)(ClampFloat(lease, 0.1f, MAX_INPUT_DURATION) * 1000000.0f) : 0;
         if (!InitReceipt(&event.m_Receipt, kind, client_id, session_id, request_id, scene_sequence, resolved, pointer_id) ||
@@ -285,6 +299,7 @@ namespace dmAutomationBridge
         }
         memcpy(event.m_Points.m_Data, points->m_Data, sizeof(InputPoint) * points->m_Count);
         event.m_Receipt.m_RequestedDuration = event.m_HoldBefore + RequestedPathDuration(points, path_mode) + event.m_HoldAfter;
+        event.m_Receipt.m_ModifierCount = event.m_ModifierCount; // echoed in receipts so callers can detect a bridge without modifier support
         if (!ArrayPush(&g_AutomationBridge.m_InputEvents, &event))
         {
             FreeInputEvent(&event);
@@ -295,6 +310,7 @@ namespace dmAutomationBridge
     }
 
     bool AddKeyInput(const char* keys, bool parse_special_keys, float key_hold,
+                     const dmHID::Key* modifiers, uint32_t modifier_count,
                      const char* client_id, const char* session_id, const char* request_id,
                      uint64_t scene_sequence, InputReceipt** receipt)
     {
@@ -307,6 +323,7 @@ namespace dmAutomationBridge
         event.m_Type = INPUT_EVENT_KEYS;
         event.m_Keys = DuplicateString(keys);
         event.m_ActiveKey = dmHID::MAX_KEY_COUNT;
+        SetEventModifiers(&event, modifiers, modifier_count);
         event.m_ParseSpecialKeys = parse_special_keys;
         event.m_HoldAfter = key_hold; // per special-key hold in seconds; 0 = single-update tap
         if (!event.m_Keys || !InitReceipt(&event.m_Receipt, "key", client_id, session_id, request_id,
@@ -317,6 +334,7 @@ namespace dmAutomationBridge
             return false;
         }
         *receipt = &g_AutomationBridge.m_InputEvents.m_Data[g_AutomationBridge.m_InputEvents.m_Count - 1].m_Receipt;
+        (*receipt)->m_ModifierCount = event.m_ModifierCount; // echoed in receipts so callers can detect a bridge without modifier support
         return true;
     }
 
@@ -475,6 +493,8 @@ namespace dmAutomationBridge
         AppendJsonString(out, InputDeviceName(receipt->m_Device));
         StringBufferAppend(out, ",\"pointer_id\":");
         AppendNumber(out, (double)receipt->m_PointerId);
+        StringBufferAppend(out, ",\"modifier_count\":");
+        AppendNumber(out, (double)receipt->m_ModifierCount);
         StringBufferAppendChar(out, '}');
     }
 
@@ -568,6 +588,57 @@ namespace dmAutomationBridge
         memcpy(name, start, length);
         name[length] = 0;
         *next_index = (uint32_t)(end - keys) + 1;
+        return true;
+    }
+
+    // Parse a comma-separated list of key names (e.g. "KEY_LSHIFT,KEY_LCTRL") into
+    // validated dmHID keys for use as chord modifiers. Deliberately loud: an empty
+    // list, an unknown name, or too many entries is an error, never silently ignored --
+    // a supplied-but-invalid modifier degrading to an unmodified gesture is exactly the
+    // kind of silent no-op the input API's validation contract exists to prevent.
+    bool ParseModifierList(const char* text, dmHID::Key* out_modifiers, uint32_t max_modifiers,
+                           uint32_t* out_count, const char** error)
+    {
+        *out_count = 0;
+        if (IsEmpty(text))
+        {
+            *error = "modifiers is empty; provide comma-separated key names such as KEY_LSHIFT,KEY_LCTRL";
+            return false;
+        }
+        const char* cursor = text;
+        while (*cursor)
+        {
+            while (*cursor == ' ' || *cursor == ',') ++cursor;
+            if (!*cursor) break;
+            const char* start = cursor;
+            while (*cursor && *cursor != ',' && *cursor != ' ') ++cursor;
+            char name[64];
+            uint32_t length = (uint32_t)(cursor - start);
+            if (length == 0 || length >= sizeof(name))
+            {
+                *error = "unsupported modifier key; use names accepted by the keys parameter, such as KEY_LSHIFT, KEY_LCTRL, or KEY_LALT";
+                return false;
+            }
+            memcpy(name, start, length);
+            name[length] = 0;
+            dmHID::Key key = KeyFromName(name);
+            if (key == dmHID::MAX_KEY_COUNT)
+            {
+                *error = "unsupported modifier key; use names accepted by the keys parameter, such as KEY_LSHIFT, KEY_LCTRL, or KEY_LALT";
+                return false;
+            }
+            if (*out_count >= max_modifiers)
+            {
+                *error = "too many modifiers; at most 4 are supported";
+                return false;
+            }
+            out_modifiers[(*out_count)++] = key;
+        }
+        if (*out_count == 0)
+        {
+            *error = "modifiers is empty; provide comma-separated key names such as KEY_LSHIFT,KEY_LCTRL";
+            return false;
+        }
         return true;
     }
 
@@ -705,6 +776,25 @@ namespace dmAutomationBridge
         ReceiptSetReason(receipt, reason);
     }
 
+    // Re-assert an event's chord modifiers for this update. The engine's HID update
+    // re-polls the OS keyboard right before extension updates each frame, wiping injected
+    // key state -- so held modifiers must be asserted every update, and simply stopping
+    // is already a clean release (one update after the primary's release, giving games
+    // that track a modifier's own key_trigger the ordering a human chord produces).
+    static bool AssertModifiers(InputEvent* event)
+    {
+        dmHID::HKeyboard keyboard = dmHID::GetKeyboard(g_AutomationBridge.m_HidContext, 0);
+        if (keyboard == dmHID::INVALID_KEYBOARD_HANDLE)
+        {
+            return false;
+        }
+        for (uint8_t i = 0; i < event->m_ModifierCount; ++i)
+        {
+            dmHID::SetKey(keyboard, event->m_Modifiers[i], true);
+        }
+        return true;
+    }
+
     static bool UpdateMouseEvent(float dt, InputEvent* event)
     {
         InputPoint* first = &event->m_Points.m_Data[0];
@@ -712,6 +802,24 @@ namespace dmAutomationBridge
         {
             FinishReceipt(&event->m_Receipt, INPUT_STATE_CANCELLED, event->m_Receipt.m_Reason);
             return true;
+        }
+        if (event->m_ModifierCount > 0)
+        {
+            if (!AssertModifiers(event))
+            {
+                FinishReceipt(&event->m_Receipt, INPUT_STATE_FAILED, "keyboard_unavailable");
+                return true;
+            }
+            if (!event->m_Pressed && !event->m_ModifierLeadDone)
+            {
+                // Modifiers lead the pointer by one update: Defold actions carry no
+                // modifier flags, so games track the modifier's own key_trigger
+                // pressed/released into a flag -- its press must reach on_input before
+                // the pointer action does, exactly as a human chord arrives.
+                event->m_ModifierLeadDone = true;
+                if (event->m_Receipt.m_State == INPUT_STATE_ACCEPTED) StartReceipt(&event->m_Receipt);
+                return false;
+            }
         }
         if (!event->m_Pressed)
         {
@@ -797,6 +905,17 @@ namespace dmAutomationBridge
             return true;
         }
         if (event->m_Receipt.m_State == INPUT_STATE_ACCEPTED) StartReceipt(&event->m_Receipt);
+        if (event->m_ModifierCount > 0)
+        {
+            AssertModifiers(event); // keyboard handle already validated above
+            if (!event->m_ModifierLeadDone)
+            {
+                // Modifiers lead the first tap by one update -- see UpdateMouseEvent's
+                // matching comment for why the ordering matters.
+                event->m_ModifierLeadDone = true;
+                return false;
+            }
+        }
         if (event->m_ActiveKey != dmHID::MAX_KEY_COUNT)
         {
             // Hold phase: the engine's own HID update re-polls the OS keyboard right before

--- a/automation_bridge/src/automation_bridge_private.h
+++ b/automation_bridge/src/automation_bridge_private.h
@@ -22,6 +22,7 @@ namespace dmAutomationBridge
     static const uint32_t MAX_INPUT_EVENTS = 64;
     static const uint32_t MAX_INPUT_HISTORY = 256;
     static const uint32_t MAX_INPUT_PATH_POINTS = 128;
+    static const uint32_t MAX_INPUT_MODIFIERS = 4;
     static const float MAX_INPUT_DURATION = 60.0f;
     static const uint32_t MAX_KEY_INPUT_BYTES = 4096;
     static const uint32_t MAX_APPLICATION_JSON_BYTES = 32768;
@@ -226,6 +227,7 @@ namespace dmAutomationBridge
         uint64_t    m_SceneSequence;
         InputDevice m_Device;
         uint32_t    m_PointerId;
+        uint8_t     m_ModifierCount;
     };
 
     struct InputEvent
@@ -252,6 +254,14 @@ namespace dmAutomationBridge
         uint32_t   m_KeyIndex;
         dmHID::Key m_ActiveKey;
         bool       m_ParseSpecialKeys;
+
+        // Chord modifiers held for the whole event (see UpdateMouseEvent/UpdateKeyEvent):
+        // re-asserted every update while the event plays, leading the primary action by
+        // one update and trailing its release by one (the engine's per-frame HID re-poll
+        // releases them automatically once assertion stops).
+        dmHID::Key m_Modifiers[MAX_INPUT_MODIFIERS];
+        uint8_t    m_ModifierCount;
+        bool       m_ModifierLeadDone;
     };
 
     struct InputVisualization
@@ -568,10 +578,14 @@ namespace dmAutomationBridge
     void ReleaseInputController(const char* client_id, const char* session_id);
     bool AddMouseInput(const Array<InputPoint>* points, InputPathMode path_mode, float hold_before, float hold_after,
                        InputDevice device, uint32_t pointer_id, bool visualize, const char* kind,
+                       const dmHID::Key* modifiers, uint32_t modifier_count,
                        const char* client_id, const char* session_id, const char* request_id,
                        uint64_t scene_sequence, float lease, bool pointer_open, InputReceipt** receipt);
     bool ValidateSpecialKeyInput(const char* keys, const char** error, uint32_t* out_special_key_count);
+    bool ParseModifierList(const char* text, dmHID::Key* out_modifiers, uint32_t max_modifiers,
+                           uint32_t* out_count, const char** error);
     bool AddKeyInput(const char* keys, bool parse_special_keys, float key_hold,
+                     const dmHID::Key* modifiers, uint32_t modifier_count,
                      const char* client_id, const char* session_id, const char* request_id,
                      uint64_t scene_sequence, InputReceipt** receipt);
     bool AppendPointerMove(uint64_t input_id, const InputPoint* point, float lease, const char** error);

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -1560,6 +1560,34 @@ class EngineClientUnitTest(unittest.TestCase):
 
         self.assertEqual([], bridge.api_requests)
 
+    def test_modifiers_are_normalized_and_forwarded(self):
+        bridge = FakeInputClient()
+
+        bridge.click((10, 10), modifiers="lshift", wait=False)
+        bridge.drag((0, 0), (10, 10), duration=0.1, modifiers=["KEY_LCTRL", "{key_lalt}"], wait=False)
+        bridge.key("Z", modifiers="LCTRL", hold=1.0, wait=False)
+        bridge.click((10, 10), wait=False)
+
+        clicked, dragged, chorded, plain = (request[2] for request in bridge.api_requests)
+        self.assertEqual("KEY_LSHIFT", clicked["modifiers"])
+        self.assertEqual("KEY_LCTRL,KEY_LALT", dragged["modifiers"])
+        self.assertEqual("KEY_LCTRL", chorded["modifiers"])
+        self.assertEqual("{KEY_Z}", chorded["keys"])
+        self.assertEqual(1.0, chorded["hold"])
+        self.assertNotIn("modifiers", plain)
+
+    def test_modifiers_reject_invalid_before_queueing(self):
+        bridge = FakeInputClient()
+
+        with self.assertRaisesRegex(ValueError, "A-Z, 0-9"):
+            bridge.click((10, 10), modifiers="COMMAND", wait=False)
+        with self.assertRaisesRegex(ValueError, "at most 4"):
+            bridge.key("Z", modifiers=["LSHIFT", "RSHIFT", "LCTRL", "RCTRL", "LALT"], wait=False)
+        with self.assertRaisesRegex(ValueError, "at least one"):
+            bridge.drag((0, 0), (10, 10), duration=0.1, modifiers=[], wait=False)
+
+        self.assertEqual([], bridge.api_requests)
+
     def test_input_interruption_scope_flushes_after_event_wait_interrupt(self):
         bridge = FakeInputClient()
 
@@ -3378,6 +3406,37 @@ class AutomationBridgeApiTest(unittest.TestCase):
                 "session_id": self.bridge.session_id,
             })
         self.assertEqual("bad_request", unheld_text.exception.code)
+
+        # Chord modifiers ride inside one FIFO event (pressed one update before the
+        # primary action, released one update after), so a modified gesture completes
+        # its normal lifecycle. Clicked at a neutral coordinate so no game element
+        # reacts and later label-count assertions stay undisturbed.
+        chorded_click = self.bridge.click((1, 1), modifiers="LSHIFT", wait="released")
+        self.assertEqual("released", chorded_click["state"])
+        # modifier_count is echoed so callers can detect a bridge that silently ignored
+        # an unknown modifiers parameter (same contract as hold's requested_duration).
+        self.assertEqual(1, chorded_click["modifier_count"])
+        chorded_key = self.bridge.key("KEY_ENTER", modifiers="LCTRL", wait="released")
+        self.assertEqual("released", chorded_key["state"])
+        self.assertEqual(1, chorded_key["modifier_count"])
+
+        with self.assertRaises(AutomationBridgeApiError) as unknown_modifier:
+            self.bridge.request("POST", "/input/click", json_body={
+                "x": 1, "y": 1,
+                "modifiers": "KEY_BOGUS",
+                "client_id": self.bridge.client_id,
+                "session_id": self.bridge.session_id,
+            })
+        self.assertEqual("unsupported_key", unknown_modifier.exception.code)
+
+        with self.assertRaises(AutomationBridgeApiError) as chorded_text:
+            self.bridge.request("POST", "/input/key", json_body={
+                "text": "hello",
+                "modifiers": "KEY_LSHIFT",
+                "client_id": self.bridge.client_id,
+                "session_id": self.bridge.session_id,
+            })
+        self.assertEqual("bad_request", chorded_text.exception.code)
 
         self.finish_merge_game()
         gui_nodes = self.bridge.elements(


### PR DESCRIPTION
## Problem

The input FIFO is strictly serial by design, which makes modifier chords unreachable: a held `{KEY_LSHIFT}` queued before a click blocks the click until the hold finishes, so by the time the click plays the modifier is already released. Shift-click multi-select, ctrl-drag duplicate, and ctrl-Z cannot be injected at all — hit in practice by an agent driving an editor-mode scene that needed shift-click multi-select.

## Change

One new request parameter rather than a concurrent queue: `modifiers` (comma-separated key names, up to four, validated against the same table as `keys`) on `/input/click`, `/input/drag`, `/input/drag_path`, `/input/pointer/open`, and `/input/key`. The chord rides **inside** the one FIFO event: the event re-asserts the modifier keys every engine update while it plays (required anyway — the engine's HID update re-polls the OS keyboard each frame), pressing them one update before the primary action and releasing one update after it. That ordering matters because Defold actions carry no modifier flags — games track a modifier's own key_trigger `pressed`/`released` into a held flag, so the modifier press must reach `on_input` before the primary action, exactly as a human chord arrives. Stopping assertion is inherently a clean release, so cancellation and lease expiry can never leave a modifier stuck down.

Lessons from #14's review applied up front:
- Validation is loud, never silently degrading: empty list, unknown name, more than four, or `modifiers` with literal text all fail the request (query and JSON body both covered).
- Receipts echo `modifier_count` so a caller can detect a bridge that ignored an unknown `modifiers` parameter — the same detectability contract `hold`'s `requested_duration` provides.
- No controller-lease implications: modifiers add no duration beyond the lead/trail updates, so existing lease sizing already covers modified gestures; `modifiers` composes with `hold` (chorded held keys) under `hold`'s existing lease sizing.
- Python wrapper: `click`, `drag`, `drag_path`, `pointer`, and `key` gain a `modifiers` argument, normalized and validated client-side before queueing.

## Validation

Built and verified live on Windows against a real project (a voxel-terrain editor whose free-fly camera binds `KEY_LSHIFT` to fly-up): `keys={KEY_F12}&hold=2&modifiers=KEY_LSHIFT` — F12 is unbound there, a pure carrier — produced two seconds of continuous camera climb (terrain visibly receding across before/after captures, draw stats dropping accordingly), receipt `accepted → released` with `actual_duration=2.013` and `modifier_count=1`. `modifiers=KEY_BOGUS` returns `unsupported_key`; `modifiers` with `text` returns `bad_request`.

## Tests

Unit: normalization/forwarding across click, drag, and a key chord composed with `hold`, plus pre-queue rejection of unknown names, more than four, and an empty list. Live suite: a chorded click at a neutral coordinate and a chorded key both reach `released` with `modifier_count` echoed, plus the `unsupported_key` and `bad_request` error paths. Full `tests.test_automation_bridge_api` passes; the one `test_tooling` failure (Metal gputrace path assertion) is pre-existing on Windows on a clean checkout and untouched here.
