### PR TITLE
Add automation diagnostics, cancellation, and application discovery

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,28 @@
+name: Python wrapper tests
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ['3.10', '3.14']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Run dependency-free Python and tooling tests
+        env:
+          PYTHONPATH: automation_bridge/automation-bridge-python
+        run: >-
+          python -m unittest
+          tests.test_automation_bridge_api.EngineClientUnitTest
+          tests.test_automation_bridge_api.EditorDiscoveryUnitTest
+          tests.test_tooling

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -64,3 +64,38 @@ Run the dependency-free suite from the repository root:
 ```sh
 PYTHONPATH=automation_bridge/automation-bridge-python python3 -m unittest tests.test_automation_bridge_api tests.test_tooling
 ```
+
+CI runs the Python and tooling tests explicitly on Linux, macOS, and Windows
+with Python 3.10 and 3.14, independently of the native Bob build. For a local run
+that never contacts an editor:
+
+```sh
+PYTHONPATH=automation_bridge/automation-bridge-python python3 -m unittest tests.test_automation_bridge_api.EngineClientUnitTest tests.test_automation_bridge_api.EditorDiscoveryUnitTest tests.test_tooling
+```
+
+Before merging changes to the shared protocol, open this sample project in
+Defold and run the complete suite with a required runtime:
+
+```sh
+AUTOMATION_BRIDGE_REQUIRE_RUNTIME=1 PYTHONPATH=automation_bridge/automation-bridge-python python3 -m unittest tests.test_automation_bridge_api tests.test_tooling
+```
+
+The suite reuses the editor, builds the sample, and closes engines it built.
+`AUTOMATION_BRIDGE_ENGINE_PORT` can select an already built sample engine; that
+process is borrowed and remains running after teardown. Editor-specific tests
+still need the editor workflow. The ordinary command skips runtime tests when
+Defold is absent; `AUTOMATION_BRIDGE_REQUIRE_RUNTIME=1` turns unavailable runtime
+setup into a failure. It never launches the editor implicitly.
+
+Runtime checks cover pagination metadata and malformed values, built/borrowed
+clients, cancellation release, competing client/session identities, native lease
+expiry, and application contracts. The sample enables `test_contracts = 1` to
+load the bounded Lua contract fixtures in `tests/application_contracts.lua`;
+dependent projects do not need this test setting. Use short leases or explicitly
+cancel held input instead of waiting out a maximum-duration operation.
+
+Merge/gesture tests use the fixture's `sample.arrange_items` command before
+selecting targets. It separates and stops existing items outside the spawn
+button's hit area; random placement can otherwise turn a drag into another spawn
+or place targets on top of each other. Input delivery still uses native receipts
+and the normal gameplay merge path.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ annotations, and input acknowledgements.
 
 ## Installation
 
+To install the matching Python wrapper without manually copying files, first
+Fetch Libraries in the target project, then run the installer from an extension
+checkout:
+
+```sh
+python3 automation_bridge/automation-bridge-python/install.py /absolute/path/to/game
+```
+
+The installer uses that game's fetched dependency archive, requires no editor
+connection or `PYTHONPATH`, and leaves `game.project` unchanged. It replaces the
+managed wrapper directory as a unit; keep your scripts outside that directory.
+
 After Defold has fetched the extension into your project, copy the
 `automation-bridge-python` directory from the extension into your project root.
 When you update the extension, update the copied Python helper directory at the
@@ -35,6 +47,20 @@ application_api = 1
 ```
 
 ## Documentation
+
+Diagnose setup without launching, building, or changing the project:
+
+```python
+from automation_bridge import editor
+
+report = editor.doctor(".", required_capabilities=("elements", "input.click"))
+for check in report.checks:
+    print(check.name, check.status, check.message, check.action or "")
+```
+
+`report.ready` requires a compatible running engine. `report.as_dict()` provides
+JSON-serializable evidence, including independently reported Python and native
+versions and runtime capabilities.
 
 - Native extension endpoint reference: [`automation_bridge/`](automation_bridge/README.md)
 - Dependency-free Python helpers for editor bootstrap, element queries, input gestures, race-free events/state/commands, semantic annotations, timeline markers, waits, screenshots, Metal GPU traces, and diagnostics: [`automation_bridge/automation-bridge-python/`](automation_bridge/automation-bridge-python/README.md)

--- a/automation_bridge/README.md
+++ b/automation_bridge/README.md
@@ -500,6 +500,49 @@ The application channel is optional. Core scene inspection and native input work
 
 Application JSON is limited to 32 KiB and 16 nested array/object levels. Commands call registered functions only; there is no endpoint for arbitrary Lua evaluation.
 
+### Application catalog
+
+`GET /application/catalog` requires `application.catalog` (version 1), advertised
+only when `application_api = 1`. It lists all registered commands, published
+states, and explicitly declared state/event contracts. Undocumented registrations
+have an empty `contract`. Declare metadata from Lua after registering a command:
+
+```lua
+automation_bridge.describe("command", "my_game.load_fixture", {
+    description = "Load a fixture and return its name when ready.",
+    input_schema = { type = "object", properties = { name = { type = "string" } }, required = { "name" } },
+    output_schema = { type = "object", properties = { loaded = { type = "string" } } },
+})
+automation_bridge.describe("state", "my_game.ui", {
+    description = "Current workflow state; published whenever the step changes.",
+    schema = { type = "object", properties = { busy = { type = "boolean" } } },
+})
+automation_bridge.describe("event", "my_game.operation_complete", {
+    description = "Emitted after completion with the caller's operation_id.",
+    schema = { type = "object", properties = { operation_id = { type = "string" } } },
+})
+```
+
+The kind is `command`, `state`, or `event`. Metadata accepts only `description`
+(1-4096 bytes), command `input_schema`/`output_schema`, or state/event `schema`.
+Schema roots must be objects with string keys or booleans. They are application
+documentation: the bridge does not validate payloads against JSON Schema or fetch
+schema references. The existing JSON size/depth limits apply to each complete
+contract, with at most 256 declarations per engine instance. Repeating a kind/name
+replaces its complete metadata. Metadata is cleared with the Lua application
+lifecycle. An event declaration does not emit an event; a state may be described
+before its first publication. Document timing and correlation rules in descriptions.
+
+The endpoint accepts exact `kind`/`name` filters, `limit` (default 50, range 0-100),
+`offset` (default 0), and a decimal string `cursor` that takes precedence over
+offset. Invalid supplied pagination values return logical `400 bad_request`.
+The response data is `{entries: [{kind, name, contract}], count, matched, offset,
+next_cursor, revision, engine_instance_id}`. A zero limit returns only metadata
+and counts. `next_cursor` is null when there is no continuation. Each page is
+consistent; restart pagination when revision or engine identity changes.
+Revision changes on registration, first state publication, metadata replacement,
+or Lua teardown, rather than on every state value update.
+
 ### Structured events and cursors
 
 Applications emit typed JSON from Lua:

--- a/automation_bridge/README.md
+++ b/automation_bridge/README.md
@@ -288,6 +288,11 @@ curl -fsS "$BASE/scene?visible=1&include=bounds,properties" | python3 -m json.to
 
 Searches elements with simple filters. This is the main discovery endpoint for automation clients.
 
+Pagination values are validated: `limit` must be an integer from 0 through 500;
+`offset` and `cursor` must be unsigned 32-bit integers. Malformed supplied values
+return `bad_request`. A valid cursor takes precedence over a valid offset. Pages
+are independent live snapshots; compare their frame and scene metadata.
+
 Query parameters:
 
 - `id`: exact element id.

--- a/automation_bridge/automation-bridge-python/AGENTS.md
+++ b/automation_bridge/automation-bridge-python/AGENTS.md
@@ -23,6 +23,8 @@
   exposes the required native feature.
 - `elements()` is paginated; use `count()` when the complete match count is
   required.
+- Use `elements_page()` for continuation cursors, match counts and snapshot
+  evidence; see `engine.ElementSelector` for typed filters and their semantics.
 - `Element` objects are snapshots. Re-query after state or scene changes. Pass
   `Element` objects to `click()` and both ends of `drag()` for stale-identity
   protection; handle `engine.StaleElementError` by re-querying.

--- a/automation_bridge/automation-bridge-python/AGENTS.md
+++ b/automation_bridge/automation-bridge-python/AGENTS.md
@@ -33,6 +33,8 @@
   validated special key.
 - Prefer events, published state, commands, acknowledgements, frame waits, and
   element waits over sleeps.
+- Discover game-specific operations with `game.application_catalog()`; command
+  argument/result and state/event schemas describe application-owned contracts.
 - Wrap interruptible work in `game.cancellation_scope(token)` using an
   `engine.CancellationToken` per operation. Native cleanup remains authoritative;
   inspect `OperationCancelled.cleanup_error` when a cleanup request is refused.

--- a/automation_bridge/automation-bridge-python/AGENTS.md
+++ b/automation_bridge/automation-bridge-python/AGENTS.md
@@ -9,6 +9,9 @@
   Never merge wrapper versions or store project code in the wrapper directory.
 - Probe a running editor with
   `editor.open_project(".", start_if_needed=False)` before launching one.
+- Use `editor.doctor(".")` for setup, version, capability and connection
+  diagnostics without launching or writing project files. Seed a wrapper with
+  `install.py PROJECT_PATH` after Fetch Libraries when it has not been copied yet.
 - macOS: a launch must run unsandboxed; an existing editor may be reused.
   Detached processes and `/usr/bin/open` do not escape the inherited sandbox.
 - Windows: if the sandbox blocks the JDK loopback connection, start Defold

--- a/automation_bridge/automation-bridge-python/AGENTS.md
+++ b/automation_bridge/automation-bridge-python/AGENTS.md
@@ -33,6 +33,9 @@
   validated special key.
 - Prefer events, published state, commands, acknowledgements, frame waits, and
   element waits over sleeps.
+- Wrap interruptible work in `game.cancellation_scope(token)` using an
+  `engine.CancellationToken` per operation. Native cleanup remains authoritative;
+  inspect `OperationCancelled.cleanup_error` when a cleanup request is refused.
 - Use atomic receipts for screenshots and recordings. Start visual inspection at
   `resolution_multiplier=0.5`; use `project.preview.render()` for editor-side
   validation without running the game. Optional diagnostics live under

--- a/automation_bridge/automation-bridge-python/README.md
+++ b/automation_bridge/automation-bridge-python/README.md
@@ -136,6 +136,19 @@ The editor bootstrap discovers `.internal/editor.port`, launches Defold when
 needed, rejects stale engine ports, and waits for Automation Bridge health.
 Pass `start_if_needed=False` to require an already-running editor.
 
+Editor discovery retries for up to `timeout` seconds (30 by default), rereading
+the port file between attempts. HTTP requests use the remaining discovery time,
+so a slow response can still reuse the editor. With automatic startup enabled,
+a missing/invalid port file or refused connection gets a five-second grace
+period (bounded by `timeout`) before launch; a newly launched editor then has its
+own `timeout` budget. Timeouts, permission failures, and HTTP/JSON errors raise
+`NotRunningError` with the underlying failure if discovery cannot recover.
+These failures do not trigger another editor launch.
+
+Use `editor.is_running(".", timeout=1)` for a single Boolean probe. A `False`
+result means the endpoint did not respond successfully; `open_project()` handles
+the retries and startup decision.
+
 ## Reliable game test loop
 
 Resize before coordinate-based input or visual assertions, then synchronize on
@@ -223,8 +236,10 @@ from automation_bridge import editor
 project = editor.open_project(".", start_if_needed=False)
 ```
 
-If this raises `NotRunningError`, the required launch procedure differs by
-platform:
+If this raises `NotRunningError`, inspect the included discovery failure first.
+A timeout or denied connection can mean the editor is already running but could
+not be reached. If the editor needs to be started, the launch procedure differs
+by platform:
 
 - **macOS:** Rerun the normal bootstrap with escalated/unsandboxed execution.
   Defold inherits the Python parent's sandbox and otherwise cannot register with

--- a/automation_bridge/automation-bridge-python/README.md
+++ b/automation_bridge/automation-bridge-python/README.md
@@ -93,6 +93,27 @@ Use `game.close_engine()` only when the script intentionally owns engine cleanup
 
 ## Public API
 
+Use `engine.ElementSelector` as a typed dictionary of supported query keywords.
+Its docstring specifies substring versus exact matching, boolean filters, and
+pagination limits. Selectors reject malformed supplied values before a request.
+
+`game.elements()` still returns a list. Use `game.elements_page()` when the next
+cursor or complete match count matters:
+
+```python
+from automation_bridge import engine
+
+selector: engine.ElementSelector = {"type": "goc", "visible": True, "limit": 20}
+page = game.elements_page(**selector)
+print(page.count, page.matched, page.scene_sequence, page.engine_frame)
+if page.next_cursor is not None:
+    next_page = game.elements_page(**selector, cursor=page.next_cursor)
+```
+
+Pagination requires `scene.pagination`. Each page is a live snapshot; a cursor
+does not freeze the scene. `element()` and `maybe_element()` reject ambiguous
+selectors even when `limit=1` would hide additional matches.
+
 The package root exposes only `editor` and `engine`.
 
 - Bootstrap: `editor.open_project(...)`, `project.build_and_run()`,

--- a/automation_bridge/automation-bridge-python/README.md
+++ b/automation_bridge/automation-bridge-python/README.md
@@ -12,6 +12,21 @@ docstrings for details.
 
 ## Install or update Automation Bridge
 
+For initial installation, run `install.py /absolute/path/to/project` from this
+directory after the target project's Fetch Libraries completes. It locates the
+archive for the configured dependency and atomically installs the wrapper without
+launching Defold or rewriting the dependency. From an existing helper installation,
+the equivalent API is `editor.install_python(project_path)`. Restart Python after
+replacing a wrapper. No project code should be stored in the managed directory.
+
+Use `editor.doctor(project_path, required_capabilities=("elements",))` to inspect
+project configuration, copied/loaded Python versions, editor installations,
+connection errors, native API compatibility, and required capabilities. It never
+launches or builds, acquires input, starts a log collector, or writes caches.
+Its `timeout` bounds each network probe; total time depends on how many candidate
+ports are inspected. Missing capabilities are failures; an unavailable launcher
+registry is a warning when an editor is already running.
+
 Once this helper directory is present, use the editor client to install or
 update the matching extension dependency and refresh the complete copied Python
 wrapper:

--- a/automation_bridge/automation-bridge-python/README.md
+++ b/automation_bridge/automation-bridge-python/README.md
@@ -143,6 +143,18 @@ The package root exposes only `editor` and `engine`.
 
 ## Bootstrap
 
+Editor connection and build helpers accept optional `client_id` and `session_id`.
+Reuse both only for the same logical automation session; independent agents must
+use distinct identities. Builds return `game.owns_engine == True`; attachment
+through the editor or a known port returns `False`. `game.session_info()` exposes
+this information without another network request.
+
+`game.close()` (also called by the engine client's context manager) releases the
+background log collector and leaves Defold running. It is idempotent; reconnect
+before making further requests. Explicit streams/captures keep their own context
+managers. Flush this session's input before closing if cancellation is intended.
+Engine termination remains the separate, explicit `game.close_engine()` operation.
+
 ```python
 from automation_bridge import editor, engine
 

--- a/automation_bridge/automation-bridge-python/README.md
+++ b/automation_bridge/automation-bridge-python/README.md
@@ -12,12 +12,13 @@ docstrings for details.
 
 ## Install or update Automation Bridge
 
-For initial installation, run `install.py /absolute/path/to/project` from this
-directory after the target project's Fetch Libraries completes. It locates the
-archive for the configured dependency and atomically installs the wrapper without
-launching Defold or rewriting the dependency. From an existing helper installation,
-the equivalent API is `editor.install_python(project_path)`. Restart Python after
-replacing a wrapper. No project code should be stored in the managed directory.
+To copy or refresh the Python wrapper, run `install.py /absolute/path/to/project`
+from this directory after the target project's Fetch Libraries completes. It
+locates the archive for the configured dependency and atomically replaces the
+wrapper without launching Defold or rewriting the dependency. From an existing
+wrapper, the equivalent API is `editor.update_python_wrapper(project_path)`.
+Restart Python after replacing a wrapper. No project code should be stored in
+the managed directory.
 
 Use `editor.doctor(project_path, required_capabilities=("elements",))` to inspect
 project configuration, copied/loaded Python versions, editor installations,

--- a/automation_bridge/automation-bridge-python/README.md
+++ b/automation_bridge/automation-bridge-python/README.md
@@ -462,6 +462,32 @@ with game.pointer((100, 100), lease=10) as pointer:
 
 ## Synchronization and observation
 
+Use a shared cancellation token when a host or another thread may stop an
+operation:
+
+```python
+token = engine.CancellationToken()
+# The controlling thread calls token.cancel("request cancelled").
+try:
+    with game.cancellation_scope(token):
+        game.key("SPACE", hold=5, wait=False)
+        game.wait_for_state("sample.game.ready", True)
+except engine.OperationCancelled as exc:
+    print(exc.reason, exc.cleanup_error)
+```
+
+Create one token per operation and enter the scope in the thread doing the work.
+Polling delays wake when cancelled; in-flight HTTP/profiler requests remain
+bounded by their transport timeouts. `game.cancellation_scope()` requests release
+of that client's queued input on cancellation. `engine.cancellation_scope()` also
+works without a client, including editor bootstrap. It cancels waits, with input
+receipt and Metal capture waits using their existing native cleanup paths.
+Pending commands receive a cancellation request; native code decides whether it
+can be honored. Running Lua callbacks cannot be preempted. Cleanup failures are
+retained in `OperationCancelled.cleanup_error`. Cancellation does not undo
+completed operations or terminate an engine. Use context managers for streams
+and recordings so they close when a scope is interrupted.
+
 Use application events and published state instead of sleeps:
 
 ```python

--- a/automation_bridge/automation-bridge-python/README.md
+++ b/automation_bridge/automation-bridge-python/README.md
@@ -462,6 +462,25 @@ with game.pointer((100, 100), lease=10) as pointer:
 
 ## Synchronization and observation
 
+Discover game-specific operations before calling them:
+
+```python
+page = game.application_catalog(kind="command")
+for entry in page.entries:
+    print(entry.name, entry.description, entry.input_schema, entry.output_schema)
+if page.next_cursor is not None:
+    following = game.application_catalog(kind="command", cursor=page.next_cursor)
+    assert (following.engine_instance_id, following.revision) == (page.engine_instance_id, page.revision)
+```
+
+`engine.ApplicationCatalogPage` retains counts, cursor, revision and engine
+identity. `engine.ApplicationEntry` exposes descriptions and schemas; use
+`kind="state"` or `kind="event"` to discover value/data contracts via `.schema`.
+Games declare metadata with Lua `automation_bridge.describe()`; see
+`examples/application_sync.script` in the extension source. Old runtimes without
+`application.catalog` fail with `UnsupportedCapabilityError` before querying the
+endpoint. Schemas document application expectations; they do not validate payloads.
+
 Use a shared cancellation token when a host or another thread may stop an
 operation:
 

--- a/automation_bridge/automation-bridge-python/README.md
+++ b/automation_bridge/automation-bridge-python/README.md
@@ -749,3 +749,9 @@ them from the extension repository root with:
 PYTHONPATH=automation_bridge/automation-bridge-python \
 python3 -m unittest tests.test_automation_bridge_api tests.test_tooling
 ```
+
+CI explicitly runs the Python/tooling unit classes on Linux, macOS and Windows
+with Python 3.10 and 3.14. The complete suite also exercises a running Defold
+sample project. Set `AUTOMATION_BRIDGE_REQUIRE_RUNTIME=1` for release checks so a
+missing editor/engine causes a failure instead of skipping runtime coverage.
+See the source repository's `DEVELOPMENT.md` for unit-only and runtime commands.

--- a/automation_bridge/automation-bridge-python/automation_bridge/application.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/application.py
@@ -1,0 +1,77 @@
+"""Discoverable application contracts supplied by the running game."""
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, Tuple, Union
+
+
+Schema = Union[Mapping[str, Any], bool]
+
+
+@dataclass(frozen=True)
+class ApplicationEntry:
+    """A registered command, published/declared state, or declared event.
+
+    ``contract`` contains application-authored descriptions and JSON Schema
+    metadata. Schemas describe intended payloads; the bridge does not validate
+    payloads against them. Empty metadata is valid for undocumented registrations.
+    """
+
+    kind: str
+    name: str
+    contract: Mapping[str, Any]
+
+    @property
+    def description(self) -> Optional[str]:
+        """Return the application-authored description, when declared."""
+        return self.contract.get("description")
+
+    @property
+    def input_schema(self) -> Optional[Schema]:
+        """Return a command's argument schema, including boolean schemas."""
+        return self.contract.get("input_schema")
+
+    @property
+    def output_schema(self) -> Optional[Schema]:
+        """Return a command's result schema, when declared."""
+        return self.contract.get("output_schema")
+
+    @property
+    def schema(self) -> Optional[Schema]:
+        """Return a state's value or an event's data schema, when declared."""
+        return self.contract.get("schema")
+
+
+@dataclass(frozen=True)
+class ApplicationCatalogPage:
+    """One catalog page with engine identity and metadata revision.
+
+    Each page is consistent. Restart pagination if ``revision`` or
+    ``engine_instance_id`` changes between pages. A declared state can precede its
+    first publication; an event declaration does not imply an emitted event.
+    """
+
+    entries: Tuple[ApplicationEntry, ...]
+    matched: int
+    offset: int
+    next_cursor: Optional[str]
+    revision: int
+    engine_instance_id: str
+    raw: Mapping[str, Any]
+
+    @property
+    def count(self) -> int:
+        """Return the number of entries on this page."""
+        return len(self.entries)
+
+    @classmethod
+    def from_raw(cls, raw: Mapping[str, Any]) -> "ApplicationCatalogPage":
+        """Wrap a native catalog response while retaining its source metadata."""
+        return cls(
+            entries=tuple(ApplicationEntry(item["kind"], item["name"], item["contract"]) for item in raw["entries"]),
+            matched=int(raw["matched"]),
+            offset=int(raw["offset"]),
+            next_cursor=raw.get("next_cursor"),
+            revision=int(raw["revision"]),
+            engine_instance_id=str(raw["engine_instance_id"]),
+            raw=raw,
+        )

--- a/automation_bridge/automation-bridge-python/automation_bridge/cancellation.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/cancellation.py
@@ -1,0 +1,101 @@
+"""Cooperative cancellation shared by Python automation and host adapters."""
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+import threading
+import time
+from typing import Iterator, Optional
+
+
+class OperationCancelled(RuntimeError):
+    """An operation stopped at a cancellation checkpoint.
+
+    Cancellation does not imply that an already submitted native operation was
+    undone. ``cleanup_error`` preserves a failed cancellation request, including
+    the native refusal to preempt a running Lua callback.
+    """
+
+    def __init__(self, reason: str = "operation cancelled"):
+        self.reason = reason
+        self.cleanup_error: Optional[BaseException] = None
+        super().__init__(reason)
+
+
+class CancellationToken:
+    """A one-shot signal that another thread may cancel.
+
+    Create one token per operation and enter ``engine.cancellation_scope(token)``
+    in the thread doing the work. Call ``token.cancel()`` from the controlling
+    thread. Polling and delays stop cooperatively; an in-flight HTTP request is
+    bounded by its transport timeout and is not forcibly interrupted.
+    """
+
+    def __init__(self) -> None:
+        self._event = threading.Event()
+        self._lock = threading.Lock()
+        self._reason = "operation cancelled"
+
+    @property
+    def cancelled(self) -> bool:
+        """Return whether cancellation was requested."""
+        return self._event.is_set()
+
+    def cancel(self, reason: str = "operation cancelled") -> None:
+        """Request cancellation, preserving the first reason."""
+        if not isinstance(reason, str) or not reason:
+            raise ValueError("cancellation reason must be a non-empty string")
+        with self._lock:
+            if not self._event.is_set():
+                self._reason = reason
+                self._event.set()
+
+    def raise_if_cancelled(self) -> None:
+        """Raise OperationCancelled when this token has been cancelled."""
+        if self.cancelled:
+            raise OperationCancelled(self._reason)
+
+
+_current_token: ContextVar[Optional[CancellationToken]] = ContextVar(
+    "automation_bridge_cancellation", default=None
+)
+
+
+@contextmanager
+def cancellation_scope(token: CancellationToken) -> Iterator[CancellationToken]:
+    """Apply a token to synchronous automation calls in this context.
+
+    Scopes restore the previous token on exit. They are local to the execution
+    context, so one agent's cancellation does not cancel another agent's work.
+    Native input waits request release through their existing cleanup paths.
+    Use ``game.cancellation_scope(token)`` to also release this client's queued
+    input if cancellation happens while waiting for scene or application state.
+    """
+    if not isinstance(token, CancellationToken):
+        raise TypeError("token must be a CancellationToken")
+    token.raise_if_cancelled()
+    previous = _current_token.set(token)
+    try:
+        yield token
+        token.raise_if_cancelled()
+    finally:
+        _current_token.reset(previous)
+
+
+def check_cancelled() -> None:
+    token = _current_token.get()
+    if token is not None:
+        token.raise_if_cancelled()
+
+
+def cancellation_active() -> bool:
+    return _current_token.get() is not None
+
+
+def cancellable_sleep(seconds: float) -> None:
+    token = _current_token.get()
+    if token is None:
+        time.sleep(seconds)
+    else:
+        token.raise_if_cancelled()
+        token._event.wait(seconds)
+        token.raise_if_cancelled()

--- a/automation_bridge/automation-bridge-python/automation_bridge/client.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/client.py
@@ -23,6 +23,7 @@ from .elements import Element, ElementPage, ElementSelector
 from .receipts import ObservationReceipt, ScreenshotReceipt
 from .waits import RetryExceptions, WaitTimeoutError, wait_until
 from .events import CommandTimeout, Event, EventStream, StateSnapshot, select_state_path
+from .application import ApplicationCatalogPage
 from .cancellation import (
     CancellationToken, OperationCancelled, cancellation_scope,
     cancellable_sleep, cancellation_active, check_cancelled,
@@ -1667,6 +1668,40 @@ class Client:
                 selected = candidate
                 if candidate.value == expected and candidate.revision > (after_revision or 0):
                     return candidate
+
+    def application_catalog(
+        self,
+        *,
+        kind: Optional[str] = None,
+        name: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+        cursor: Optional[str] = None,
+    ) -> ApplicationCatalogPage:
+        """Discover application commands, states, events, and their contracts.
+
+        Requires ``application.catalog``. ``kind`` is command, state, or event;
+        ``name`` filters an exact name. All registered commands and published
+        states are listed, including those without metadata. Unpublished states
+        and events appear after Lua ``automation_bridge.describe()`` declarations.
+        Schemas are descriptive metadata and do not enforce payload validation.
+
+        ``limit`` is 0-100 (zero requests only the match count). Pass the returned
+        string ``next_cursor`` with the same filters to continue. Cursor takes
+        precedence over ``offset``; both must be valid unsigned 32-bit values.
+        Restart pagination if the catalog revision or engine identity changes.
+        """
+        if kind is not None and kind not in ("command", "state", "event"):
+            raise ValueError("kind must be command, state, or event")
+        if name is not None and (not isinstance(name, str) or not name or "\0" in name or len(name.encode("utf-8")) > 128):
+            raise ValueError("name must be a non-empty string of at most 128 UTF-8 bytes")
+        if isinstance(limit, bool) or not isinstance(limit, int) or not 0 <= limit <= 100:
+            raise ValueError("limit must be an integer from 0 through 100")
+        pagination = {"limit": limit, "offset": offset, "cursor": cursor}
+        self._validate_selector(pagination)
+        self._require_cached_capability("application.catalog")
+        data = self._request("GET", "/application/catalog", {"kind": kind, "name": name, **pagination})
+        return ApplicationCatalogPage.from_raw(data)
 
     def start_command(self, name: str, data: Any = None, timeout: float = 30.0) -> JsonDict:
         """Submit a registered named Lua command and return its pending id."""

--- a/automation_bridge/automation-bridge-python/automation_bridge/client.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/client.py
@@ -725,6 +725,9 @@ class Client:
         required_capabilities: Sequence[str] = (),
     ):
         """Create a correlated client for an already-known engine service port."""
+        for name, value in (("client_id", client_id), ("session_id", session_id)):
+            if value is not None and (not isinstance(value, str) or not value):
+                raise ValueError(f"{name} must be a non-empty string when supplied")
         self.port = int(port)
         self.timeout = timeout
         self.base_url = f"http://127.0.0.1:{self.port}/automation-bridge/v2"
@@ -740,6 +743,62 @@ class Client:
         self._active_traces: List[Any] = []
         self._required_capabilities = set(required_capabilities)
         self._last_health: Optional[JsonDict] = None
+        self._owns_engine = False
+        self._project_root: Optional[Path] = None
+        self._closed = False
+
+    @property
+    def owns_engine(self) -> bool:
+        """Whether this client built the engine rather than attaching to it.
+
+        This describes lifecycle intent, not permission. ``close()`` leaves
+        the process running; ``close_engine()`` explicitly exits it, including
+        when deliberately called on an attached client.
+        """
+        return self._owns_engine
+
+    @property
+    def closed(self) -> bool:
+        """Whether this client's local resources have been released."""
+        return self._closed
+
+    def session_info(self) -> JsonDict:
+        """Return session identity and lifecycle ownership without native requests."""
+        return {
+            "client_id": self.client_id,
+            "session_id": self.session_id,
+            "engine_instance_id": self.engine_instance_id,
+            "project_path": str(self._project_root) if self._project_root else None,
+            "port": self.port,
+            "owns_engine": self.owns_engine,
+            "closed": self.closed,
+        }
+
+    def close(self) -> None:
+        """Release the background collector without sending native mutations.
+
+        Closing is idempotent and prevents further requests through this client.
+        Explicit streams and captures retain their own context-manager lifecycle.
+        Use ``input.flush()`` before closing to cancel this session's input, and
+        ``close_engine()`` only when engine termination is intended.
+        """
+        if not self._closed:
+            self._logs.close()
+            self._closed = True
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise AutomationBridgeError("engine client is closed; reconnect to continue")
+
+    def __enter__(self) -> "Client":
+        self._ensure_open()
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        if exc_type is None:
+            self.close()
+        else:
+            _cleanup_without_masking(self.close)
 
     @property
     def input(self) -> InputController:
@@ -758,9 +817,15 @@ class Client:
         build_command: Optional[str] = None,
         timeout: float = 20.0,
         required_capabilities: Sequence[str] = (),
+        client_id: Optional[str] = None,
+        session_id: Optional[str] = None,
     ) -> "Client":
         """Private editor-owned bootstrap hook for engine discovery."""
         fresh_build = build_command is not None
+        session_identity = {key: value for key, value in (("client_id", client_id), ("session_id", session_id)) if value is not None}
+        for name, value in session_identity.items():
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"{name} must be a non-empty string when supplied")
         if fresh_build:
             cls._close_candidate_engine_ports(editor)
             time.sleep(0.5)
@@ -778,6 +843,7 @@ class Client:
                     service_port,
                     profiler_url=profiler_url,
                     required_capabilities=required_capabilities,
+                    **session_identity,
                 )
                 health = bridge.health()
                 if not editor._validate_cached_engine_health(
@@ -809,6 +875,8 @@ class Client:
             if profiler_url:
                 editor._remember_remotery_url(profiler_url)
             bridge.logs.start()
+            bridge._owns_engine = fresh_build
+            bridge._project_root = Path(editor.root)
             return bridge
 
         if not fresh_build:
@@ -1905,6 +1973,13 @@ class Client:
 
     def close_engine(self, timeout: float = 2.0) -> None:
         """Ask the running Defold engine to exit, falling back to the local listener PID."""
+        self._ensure_open()
+        try:
+            self._close_engine(timeout)
+        finally:
+            self.close()
+
+    def _close_engine(self, timeout: float) -> None:
         self._logs.close()
         url = f"http://127.0.0.1:{self.port}/post/@system/exit"
         try:
@@ -2258,6 +2333,7 @@ class Client:
         json_body: Optional[Mapping[str, Any]] = None,
     ) -> JsonDict:
         url = self.base_url + path
+        self._ensure_open()
         encoded_params = self._encoded_params(params)
         if encoded_params:
             url += "?" + urllib.parse.urlencode(encoded_params)
@@ -2287,6 +2363,7 @@ class Client:
         return data
 
     def _request_json(self, method: str, path: str, payload: Mapping[str, Any]) -> JsonDict:
+        self._ensure_open()
         url = self.base_url + path
         compact_payload = {key: value for key, value in payload.items() if value is not None}
         data = json.dumps(compact_payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
@@ -2387,6 +2464,7 @@ class Client:
             trace.record(kind, payload)
 
     def _post_engine_message(self, path: str, payload: bytes, timeout: Optional[float] = None) -> bytes:
+        self._ensure_open()
         url = f"http://127.0.0.1:{self.port}{path}"
         status, body = request_bytes(url, payload, timeout=self.timeout if timeout is None else timeout)
         if status < 200 or status >= 300:

--- a/automation_bridge/automation-bridge-python/automation_bridge/client.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/client.py
@@ -14,6 +14,7 @@ import urllib.parse
 import urllib.request
 import uuid
 from collections import deque
+from contextlib import contextmanager
 from pathlib import Path
 import threading
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
@@ -22,6 +23,10 @@ from .elements import Element, ElementPage, ElementSelector
 from .receipts import ObservationReceipt, ScreenshotReceipt
 from .waits import RetryExceptions, WaitTimeoutError, wait_until
 from .events import CommandTimeout, Event, EventStream, StateSnapshot, select_state_path
+from .cancellation import (
+    CancellationToken, OperationCancelled, cancellation_scope,
+    cancellable_sleep, cancellation_active, check_cancelled,
+)
 
 
 JsonDict = Dict[str, Any]
@@ -211,18 +216,29 @@ class EngineLogStream:
         if sock is None:
             return b""
         previous_timeout = sock.gettimeout()
+        budget = previous_timeout if timeout is None else timeout
+        deadline = time.monotonic() + budget if budget is not None else None
         timeout_changed = timeout is not None
         if timeout is not None:
             sock.settimeout(timeout)
+        if cancellation_active() and (budget is None or budget > 0.1):
+            sock.settimeout(0.1)
+            timeout_changed = True
         try:
             while True:
+                check_cancelled()
                 newline = self._buffer.find(b"\n")
                 if newline >= 0:
                     line = bytes(self._buffer[: newline + 1])
                     del self._buffer[: newline + 1]
                     return line
 
-                chunk = sock.recv(4096)
+                try:
+                    chunk = sock.recv(4096)
+                except socket.timeout:
+                    if cancellation_active() and (deadline is None or time.monotonic() < deadline):
+                        continue
+                    return b""
                 if not chunk:
                     if not self._buffer:
                         self.close()
@@ -410,6 +426,7 @@ class InputController:
         last = receipt
         try:
             while True:
+                check_cancelled()
                 if last is None or last.state == "accepted" or state == "released":
                     last = self.status(input_id)
                 if last.state in {"cancelled", "failed"}:
@@ -425,8 +442,8 @@ class InputController:
                         f"input {input_id} did not reach {state!r} within {timeout}s; "
                         f"last state was {last.state!r}"
                     )
-                time.sleep(max(0.0, min(interval, deadline - time.monotonic())))
-        except BaseException:
+                cancellable_sleep(max(0.0, min(interval, deadline - time.monotonic())))
+        except BaseException as interrupted:
             if cancel_on_interrupt:
                 def cleanup() -> None:
                     if flush_on_interrupt:
@@ -436,7 +453,11 @@ class InputController:
 
                 # Keep cleanup failures from replacing the original timeout,
                 # cancellation, KeyboardInterrupt, or API error.
-                _cleanup_without_masking(cleanup)
+                try:
+                    cleanup()
+                except BaseException as cleanup_error:
+                    if isinstance(interrupted, OperationCancelled):
+                        interrupted.cleanup_error = cleanup_error
             raise
 
     def cancel(self, input_id: int, release: bool = True) -> InputReceipt:
@@ -790,6 +811,28 @@ class Client:
         if self._closed:
             raise AutomationBridgeError("engine client is closed; reconnect to continue")
 
+    @contextmanager
+    def cancellation_scope(self, token: CancellationToken):
+        """Cancel waits and request release of this session's input on cancellation.
+
+        One token belongs to one operation. Use separate clients/identities for
+        independent operations; cleanup only targets this client's native lease.
+        A cleanup failure is retained on ``OperationCancelled.cleanup_error``.
+        """
+        entered = False
+        try:
+            with cancellation_scope(token):
+                entered = True
+                yield token
+        except OperationCancelled as exc:
+            if entered:
+                try:
+                    self.input.flush(release=True)
+                except Exception as cleanup_error:
+                    if exc.cleanup_error is None:
+                        exc.cleanup_error = cleanup_error
+            raise
+
     def __enter__(self) -> "Client":
         self._ensure_open()
         return self
@@ -821,6 +864,7 @@ class Client:
         session_id: Optional[str] = None,
     ) -> "Client":
         """Private editor-owned bootstrap hook for engine discovery."""
+        check_cancelled()
         fresh_build = build_command is not None
         session_identity = {key: value for key, value in (("client_id", client_id), ("session_id", session_id)) if value is not None}
         for name, value in session_identity.items():
@@ -828,7 +872,7 @@ class Client:
                 raise ValueError(f"{name} must be a non-empty string when supplied")
         if fresh_build:
             cls._close_candidate_engine_ports(editor)
-            time.sleep(0.5)
+            cancellable_sleep(0.5)
             editor._build_and_run_command(build_command, timeout=timeout)
 
         def connect_candidate(
@@ -937,7 +981,7 @@ class Client:
         if build_command is None:
             raise RuntimeError("stale-build recovery requires a build command")
         cls._close_candidate_engine_ports(editor)
-        time.sleep(0.5)
+        cancellable_sleep(0.5)
         editor._build_and_run_command(build_command, timeout=timeout)
         return cls._wait_for_bridge(
             bridge_after_build,
@@ -960,6 +1004,7 @@ class Client:
         last_error: Optional[BaseException] = None
         attempts = 0
         while time.monotonic() < deadline:
+            check_cancelled()
             attempts += 1
             try:
                 bridge = probe()
@@ -969,7 +1014,7 @@ class Client:
                 raise
             except retry_exceptions as exc:
                 last_error = exc
-            time.sleep(0.1)
+            cancellable_sleep(0.1)
         error = WaitTimeoutError(
             message,
             last_value=None,
@@ -1275,6 +1320,7 @@ class Client:
         down and released one update after it comes up, so bindings that track the
         modifier's own key trigger observe the same ordering a human chord produces.
         """
+        check_cancelled()
         if isinstance(target, Element):
             json_body: Dict[str, Any] = {"id": target.id}
             if target.logical_id:
@@ -1322,6 +1368,7 @@ class Client:
         ``"LCTRL"`` for ctrl-drag), pressed one update before the pointer goes down
         and released one update after the final up.
         """
+        check_cancelled()
         if self._is_element_ref(from_target) and self._is_element_ref(to_target):
             json_body: Dict[str, Any] = {
                 "from_id": self._element_id(from_target),
@@ -1384,6 +1431,7 @@ class Client:
         ``modifiers`` holds up to four keys as a chord for the whole gesture, pressed
         one update before the pointer goes down and released one update after the up.
         """
+        check_cancelled()
         normalized_points = [self._point(point) for point in points]
         if path not in {"sampled", "linear", "quadratic", "cubic"}:
             raise ValueError("path must be sampled, linear, quadratic, or cubic")
@@ -1448,6 +1496,7 @@ class Client:
         ``modifiers`` holds up to four keys as a chord for the whole session, pressed
         one update before the pointer goes down and released one update after the up.
         """
+        check_cancelled()
         lease = self._input_duration(lease, "lease")
         if lease <= 0:
             raise ValueError("lease must be greater than zero")
@@ -1481,6 +1530,7 @@ class Client:
         flush_on_interrupt: bool = False,
     ) -> InputReceipt:
         """Queue FIFO text input and optionally wait for native completion."""
+        check_cancelled()
         json_body = self._input_json_body()
         json_body.update({"text": text, "expected_scene_sequence": expected_scene_sequence})
         receipt = InputReceipt(self._request("POST", "/input/key", json_body=json_body))
@@ -1510,6 +1560,7 @@ class Client:
         continuous per-frame actions a physically held key generates. When
         waiting on a long hold, raise ``timeout`` above the hold duration.
         """
+        check_cancelled()
         hold = self._input_duration(hold, "hold")
         keys = f"{{{self._normalize_key(key)}}}"
         if hold > 0.0:
@@ -1584,6 +1635,7 @@ class Client:
         matching value must not satisfy a wait for a *new* publication.
         ``state_name`` disambiguates a path before that state has first appeared.
         """
+        check_cancelled()
         snapshot = self.states()
         entries = [item for item in snapshot.get("states", []) if isinstance(item, Mapping)]
         current_revision = int(snapshot.get("revision", 0))
@@ -1593,6 +1645,7 @@ class Client:
         cursor = current_revision if after_revision is None else int(after_revision)
         deadline = time.monotonic() + timeout
         while True:
+            check_cancelled()
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 observed = selected.value if selected is not None else "<unpublished>"
@@ -1601,6 +1654,8 @@ class Client:
                     f"last value={observed!r}, revision={cursor}"
                 )
             safe_wait = min(remaining, max(0.0, float(self.timeout) - 0.1), 1.0)
+            if cancellation_active():
+                safe_wait = min(safe_wait, 0.1)
             changed = self._request(
                 "GET", "/state/wait",
                 {"after_revision": cursor, "timeout_ms": int(safe_wait * 1000), "name": state_name},
@@ -1615,6 +1670,7 @@ class Client:
 
     def start_command(self, name: str, data: Any = None, timeout: float = 30.0) -> JsonDict:
         """Submit a registered named Lua command and return its pending id."""
+        check_cancelled()
         if timeout <= 0 or timeout > 300:
             raise ValueError("command timeout must be greater than 0 and at most 300 seconds")
         payload = json.dumps({} if data is None else data, allow_nan=False, separators=(",", ":"))
@@ -1639,10 +1695,28 @@ class Client:
         return self._request("DELETE", "/commands", {"id": int(command_id)})
 
     def wait_for_command(self, command_id: int, timeout: float = 30.0, interval: float = 0.02) -> JsonDict:
-        """Wait for a command result, cancelling a still-pending command on timeout."""
+        """Wait for completion, requesting pending-command cancellation on interruption.
+
+        Running Lua callbacks cannot be preempted. A failed native cancellation
+        is preserved as ``OperationCancelled.cleanup_error``.
+        """
+        try:
+            return self._wait_for_command(command_id, timeout, interval)
+        except OperationCancelled as exc:
+            try:
+                self.cancel_command(command_id)
+            except Exception as cleanup_error:
+                exc.cleanup_error = cleanup_error
+            raise
+        except (KeyboardInterrupt, SystemExit):
+            _cleanup_without_masking(lambda: self.cancel_command(command_id))
+            raise
+
+    def _wait_for_command(self, command_id: int, timeout: float, interval: float) -> JsonDict:
         deadline = time.monotonic() + timeout
         terminal = {"completed", "failed", "cancelled", "timed_out"}
         while True:
+            check_cancelled()
             status = self.command_status(command_id)
             if status.get("state") in terminal:
                 return status
@@ -1654,7 +1728,7 @@ class Client:
                 except AutomationBridgeError as exc:
                     cancellation_error = exc
                 raise CommandTimeout(command_id, timeout, cancellation_error) from cancellation_error
-            time.sleep(min(interval, remaining))
+            cancellable_sleep(min(interval, remaining))
 
     def command(self, name: str, data: Any = None, timeout: float = 30.0) -> JsonDict:
         """Run a registered command and return its terminal result record."""
@@ -1697,6 +1771,7 @@ class Client:
         retry_exceptions: RetryExceptions = (),
     ) -> ScreenshotReceipt:
         """Capture a PNG, optionally returning a lower-resolution derived image."""
+        check_cancelled()
         if not isinstance(after_frames, int) or after_frames < 0 or after_frames > 600:
             raise ValueError("after_frames must be an integer from 0 through 600")
         if resolution_multiplier is not None:
@@ -1887,6 +1962,7 @@ class Client:
 
     def resize(self, width: int, height: int, wait: float = 0.25) -> JsonDict:
         """Request a resize and return requested, window, viewport, and outcome data."""
+        check_cancelled()
         _validate_screen_size(width, height)
         capabilities = self.health().get("capabilities", [])
         if not isinstance(capabilities, (list, tuple, set)) or "screen.resize" not in capabilities:
@@ -1903,7 +1979,7 @@ class Client:
                 window = screen.get("window")
                 if isinstance(window, Mapping) and window.get("width") == width and window.get("height") == height:
                     break
-                time.sleep(min(0.02, max(0.0, deadline - time.monotonic())))
+                cancellable_sleep(min(0.02, max(0.0, deadline - time.monotonic())))
         window = screen.get("window") if isinstance(screen, Mapping) else None
         observed_width = None
         observed_height = None
@@ -1964,6 +2040,7 @@ class Client:
 
     def reboot(self, *args: str, wait: bool = True, timeout: Optional[float] = None) -> None:
         """Reboot the engine through `/post/@system/reboot` with up to six command-line args."""
+        check_cancelled()
         payload = _encode_system_reboot(args)
         self._post_engine_message("/post/@system/reboot", payload, timeout=timeout)
         self._last_window_size = None
@@ -2016,7 +2093,7 @@ class Client:
                 self.health()
             except AutomationBridgeError:
                 return True
-            time.sleep(0.05)
+            cancellable_sleep(0.05)
         return False
 
     def _wait_ready_after_reboot(self, timeout: float) -> JsonDict:
@@ -2038,7 +2115,7 @@ class Client:
             remaining = deadline - time.monotonic()
             if remaining <= 0.0:
                 break
-            time.sleep(min(0.05, remaining))
+            cancellable_sleep(min(0.05, remaining))
 
         try:
             data = self.health()

--- a/automation_bridge/automation-bridge-python/automation_bridge/client.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/client.py
@@ -421,11 +421,12 @@ class InputController:
         if receipt is not None:
             if receipt.state in {"cancelled", "failed"}:
                 raise InputExecutionError(receipt)
-            if state == "accepted" and receipt.state in {"accepted", "started", "released"}:
-                return receipt
         deadline = time.monotonic() + max(0.0, timeout)
         last = receipt
         try:
+            check_cancelled()
+            if receipt is not None and state == "accepted" and receipt.state in {"accepted", "started", "released"}:
+                return receipt
             while True:
                 check_cancelled()
                 if last is None or last.state == "accepted" or state == "released":

--- a/automation_bridge/automation-bridge-python/automation_bridge/client.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/client.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import threading
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
 
-from .elements import Element
+from .elements import Element, ElementPage, ElementSelector
 from .receipts import ObservationReceipt, ScreenshotReceipt
 from .waits import RetryExceptions, WaitTimeoutError, wait_until
 from .events import CommandTimeout, Event, EventStream, StateSnapshot, select_state_path
@@ -1107,27 +1107,55 @@ class Client:
         return self._request("GET", "/scene", params)
 
     def elements(self, **selector: Any) -> List[Element]:
-        """Return one server-filtered page of inspectable scene elements."""
+        """Return one page of elements; see ``engine.ElementSelector`` for filters.
+
+        The default limit is 50. Use ``elements_page()`` to retain the native
+        match count, continuation cursor and snapshot metadata, or ``count()``
+        when only the complete match count is required.
+        """
         elements, _, _ = self._select_elements(selector)
         return elements
 
+
+    def elements_page(self, **selector: Any) -> ElementPage:
+        """Return elements and their native pagination and snapshot metadata.
+
+        Accepts the same ``engine.ElementSelector`` keywords as ``elements()``.
+        Keep filters unchanged when passing ``page.next_cursor`` as ``cursor``.
+        A later page can describe a newer frame; it is not an atomic scene dump.
+        """
+        self._validate_selector(selector)
+        self._require_cached_capability("scene.pagination")
+        data = self._request("GET", "/elements", self._server_params(selector, selector.get("limit", 50)))
+        return ElementPage.from_raw(data)
+
+
     def element(self, **selector: Any) -> Element:
-        """Return exactly one matching element or raise `SelectorError`."""
+        """Return exactly one matching element or raise ``SelectorError``.
+
+        Uses ``engine.ElementSelector`` filters. Pagination options cannot make
+        an ambiguous selector unique; use exact names or automation IDs.
+        """
         elements, metadata, selector_text = self._select_elements(selector)
-        if len(elements) == 1:
+        if len(elements) == 1 and metadata.get("matched", len(elements)) == 1:
             return elements[0]
         error = SelectorError(self._selector_error("expected exactly one element", selector, selector_text, elements, metadata))
         self._trace_record("selector_error", {"selector": selector, "error": str(error)})
         raise error
 
+
     def maybe_element(self, **selector: Any) -> Optional[Element]:
         """Return zero or one matching element, raising if multiple elements match."""
         elements, metadata, selector_text = self._select_elements(selector)
-        if len(elements) <= 1:
-            return elements[0] if elements else None
+        matched = metadata.get("matched", len(elements))
+        if matched == 0:
+            return None
+        if len(elements) == 1 and matched == 1:
+            return elements[0]
         error = SelectorError(self._selector_error("expected zero or one element", selector, selector_text, elements, metadata))
         self._trace_record("selector_error", {"selector": selector, "error": str(error)})
         raise error
+
 
     def element_by_id(
         self,
@@ -2448,6 +2476,22 @@ class Client:
         unknown = set(selector) - self._SELECTOR_KEYS
         if unknown:
             raise TypeError(f"unknown element selector keys: {', '.join(sorted(unknown))}")
+        boolean_keys = {"enabled", "has_bounds", "visible_and_enabled", "visible", "case_sensitive"}
+        for key, value in selector.items():
+            if value is None:
+                continue
+            if key in boolean_keys:
+                if not isinstance(value, bool):
+                    raise TypeError(f"{key} must be a bool")
+            elif key in {"limit", "offset"}:
+                maximum = 500 if key == "limit" else 0xFFFFFFFF
+                if isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= maximum:
+                    raise ValueError(f"{key} must be an integer from 0 through {maximum}")
+            elif key == "cursor":
+                if not isinstance(value, str) or not value.isascii() or not value.isdigit() or int(value) > 0xFFFFFFFF:
+                    raise ValueError("cursor must be an unsigned decimal continuation string")
+            elif key != "include" and not isinstance(value, str):
+                raise TypeError(f"{key} must be a string")
 
     def _has_client_filters(self, selector: Mapping[str, Any]) -> bool:
         return any(selector.get(key) is not None for key in self._CLIENT_FILTERS)

--- a/automation_bridge/automation-bridge-python/automation_bridge/diagnostics.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/diagnostics.py
@@ -115,7 +115,7 @@ def inspect_project(
             None if same else "Use the complete project wrapper and restart Python after installation or update.",
         ))
     except (OSError, ValueError, SyntaxError) as exc:
-        checks.append(DiagnosticCheck("python_wrapper", "warning", str(exc), "Run editor.install_python(project_path) after Fetch Libraries."))
+        checks.append(DiagnosticCheck("python_wrapper", "warning", str(exc), "Run editor.update_python_wrapper(project_path) after Fetch Libraries."))
 
     try:
         available = editor.installations()

--- a/automation_bridge/automation-bridge-python/automation_bridge/diagnostics.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/diagnostics.py
@@ -1,0 +1,175 @@
+"""Non-launching diagnostics for Automation Bridge project setup."""
+
+import ast
+from dataclasses import asdict, dataclass
+import math
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence, Tuple, Union
+
+
+@dataclass(frozen=True)
+class DiagnosticCheck:
+    """One named check with status ok, warning, or error and a suggested action."""
+
+    name: str
+    status: str
+    message: str
+    action: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class DoctorReport:
+    """Setup evidence collected without launching, building, or updating a project.
+
+    ``ready`` means a compatible engine was reached. ``ok`` means no check
+    failed; warnings such as an absent installation registry may coexist with
+    a healthy running editor. Versions are reported independently because
+    native and Python package version numbers are not required to be equal.
+    """
+
+    project_path: Path
+    checks: Tuple[DiagnosticCheck, ...]
+    python_package_version: str
+    installed_python_version: Optional[str] = None
+    health: Optional[Mapping[str, Any]] = None
+
+    @property
+    def ok(self) -> bool:
+        return all(check.status != "error" for check in self.checks)
+
+    @property
+    def ready(self) -> bool:
+        return self.health is not None and self.ok
+
+    def as_dict(self) -> dict:
+        """Return a JSON-serializable report for CLIs and agent adapters."""
+        result = asdict(self)
+        result["project_path"] = str(self.project_path)
+        result.update(ok=self.ok, ready=self.ready)
+        return result
+
+
+def _wrapper_version(path: Path) -> str:
+    # Read metadata without importing or executing a project's copied package.
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for statement in tree.body:
+        if isinstance(statement, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "PYTHON_PACKAGE_VERSION"
+            for target in statement.targets
+        ):
+            value = ast.literal_eval(statement.value)
+            if isinstance(value, str):
+                return value
+    raise ValueError("wrapper does not declare PYTHON_PACKAGE_VERSION")
+
+
+def inspect_project(
+    project_path: Union[str, Path],
+    *,
+    required_capabilities: Sequence[str] = (),
+    timeout: float = 2.0,
+) -> DoctorReport:
+    from . import editor
+    from .client import Client, PYTHON_PACKAGE_VERSION
+
+    if isinstance(timeout, bool) or not isinstance(timeout, (float, int)) or not math.isfinite(timeout) or timeout <= 0:
+        raise ValueError("diagnostic timeout must be finite and greater than zero")
+    root = Path(project_path).expanduser().resolve()
+    checks = []
+    installed_version = None
+    health = None
+
+    def report() -> DoctorReport:
+        return DoctorReport(root, tuple(checks), PYTHON_PACKAGE_VERSION, installed_version, health)
+
+    try:
+        configuration = editor._read_project_configuration(root)
+    except (OSError, ValueError) as exc:
+        checks.append(DiagnosticCheck("project", "error", str(exc), "Select a directory containing a valid game.project."))
+        return report()
+    checks.append(DiagnosticCheck("project", "ok", str(root / "game.project")))
+    local_extension = (root / "automation_bridge" / "ext.manifest").is_file()
+    try:
+        dependency = editor._bridge_dependency(configuration)
+    except editor.AutomationBridgeUpdateError as exc:
+        if local_extension and "missing" in str(exc):
+            checks.append(DiagnosticCheck("dependency", "ok", "Using the local native extension."))
+        else:
+            checks.append(DiagnosticCheck("dependency", "error", str(exc), "Add one Automation Bridge dependency and Fetch Libraries."))
+    else:
+        try:
+            archive = editor._automation_bridge_archive_path(root, dependency)
+            checks.append(DiagnosticCheck("dependency", "ok", str(archive)))
+        except editor.AutomationBridgeUpdateError as exc:
+            checks.append(DiagnosticCheck("dependency", "warning", str(exc), "Run Defold's Fetch Libraries command."))
+
+    installed = root / "automation-bridge-python" / "automation_bridge" / "client.py"
+    if local_extension and not installed.exists():
+        installed = root / "automation_bridge" / "automation-bridge-python" / "automation_bridge" / "client.py"
+    try:
+        installed_version = _wrapper_version(installed)
+        same = installed_version == PYTHON_PACKAGE_VERSION
+        checks.append(DiagnosticCheck(
+            "python_wrapper", "ok" if same else "warning",
+            f"Loaded {PYTHON_PACKAGE_VERSION}; project copy {installed_version}.",
+            None if same else "Use the complete project wrapper and restart Python after installation or update.",
+        ))
+    except (OSError, ValueError, SyntaxError) as exc:
+        checks.append(DiagnosticCheck("python_wrapper", "warning", str(exc), "Run editor.install_python(project_path) after Fetch Libraries."))
+
+    try:
+        available = editor.installations()
+        checks.append(DiagnosticCheck(
+            "editor_installation", "ok" if available else "warning",
+            f"Found {len(available)} registered Defold installations.",
+            None if available else "Install Defold or open the project manually.",
+        ))
+    except (OSError, ValueError, editor.Error) as exc:
+        checks.append(DiagnosticCheck("editor_installation", "warning", str(exc), "Open the project manually if automatic launcher discovery is unavailable."))
+
+    try:
+        project = editor.Client(root)
+        project._check_connection(timeout=timeout)
+        checks.append(DiagnosticCheck("editor_connection", "ok", f"Editor responds on port {project.port}."))
+    except (OSError, ValueError, editor.Error) as exc:
+        checks.append(DiagnosticCheck(
+            "editor_connection", "error", str(exc),
+            "Open this project in Defold outside a restricted sandbox, then probe again; check local connection permissions if it is already running.",
+        ))
+        return report()
+
+    errors = []
+    cached_port = project._cached_engine_service_port_value()
+    if cached_port is not None:
+        try:
+            candidate = Client(cached_port, timeout=timeout, required_capabilities=required_capabilities)
+            observed = candidate.health()
+            if project._cached_engine_health_matches(cached_port, observed):
+                health = observed
+            else:
+                errors.append("Cached engine identity no longer matches.")
+        except editor.Error as exc:
+            errors.append(str(exc))
+    if health is None:
+        try:
+            status, console = editor.request_json(f"{project.base_url}/console", timeout=timeout)
+            if status < 200 or status >= 300:
+                raise editor.HttpError("GET", f"{project.base_url}/console", str(console), status=status)
+            lines = console.get("lines", [])
+            for port in project._current_registration_engine_service_ports(lines)[:8]:
+                try:
+                    observed = Client(port, timeout=timeout, required_capabilities=required_capabilities).health()
+                    if project._validate_cached_engine_health(port, observed, fresh_build=True):
+                        health = observed
+                        break
+                    errors.append(f"Engine identity mismatch on port {port}.")
+                except editor.Error as exc:
+                    errors.append(str(exc))
+        except (editor.Error, OSError, ValueError) as exc:
+            errors.append(str(exc))
+    checks.append(DiagnosticCheck(
+        "engine_connection", "ok" if health is not None else "error",
+        "Compatible engine and required capabilities verified." if health is not None else "; ".join(errors) or "No engine registered in this project's editor console.",
+        None if health is not None else "Build and run a debug game with the matching extension; inspect the reported API/capability or connection error.",
+    ))
+    return report()

--- a/automation_bridge/automation-bridge-python/automation_bridge/editor.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/editor.py
@@ -25,6 +25,7 @@ from typing import Any, Iterator, Mapping, Optional, Sequence, TYPE_CHECKING, Un
 from .client import AutomationBridgeError, HttpError, request_json, request_raw
 from .preferences import PreferenceKey, Preferences
 from .waits import WaitTimeoutError, wait_until
+from .diagnostics import DiagnosticCheck, DoctorReport
 
 if TYPE_CHECKING:
     from .client import Client as EngineClient
@@ -247,6 +248,25 @@ def _automation_bridge_archive_path(project_root: Path, dependency_url: str) -> 
             f"Defold reported the dependency fetched, but its archive is missing from {library_directory}"
         )
     return max(candidates, key=lambda path: path.stat().st_mtime_ns)
+
+
+def _read_project_configuration(root: Path) -> configparser.ConfigParser:
+    configuration = configparser.ConfigParser(interpolation=None)
+    try:
+        configuration.read_string((root / "game.project").read_text(encoding="utf-8"))
+    except configparser.Error as exc:
+        raise ValueError(f"invalid game.project: {exc}") from exc
+    return configuration
+
+
+def _bridge_dependency(configuration: configparser.ConfigParser) -> str:
+    values = configuration.items("project") if configuration.has_section("project") else ()
+    dependencies = [value.strip() for key, value in values if key.startswith("dependencies#") and _is_automation_bridge_dependency(value.strip())]
+    if not dependencies:
+        raise AutomationBridgeUpdateError("Automation Bridge dependency is missing; configure one dependency")
+    if len(dependencies) != 1:
+        raise AutomationBridgeUpdateError("Automation Bridge dependency is ambiguous; configure exactly one dependency")
+    return dependencies[0]
 
 
 def _replace_python_wrapper(archive_path: Path, destination: Path) -> None:
@@ -1378,6 +1398,41 @@ def is_running(root: Union[str, Path] = ".", *, timeout: float = 1.0) -> bool:
         return False
 
 
+def doctor(
+    project_path: Union[str, Path] = ".",
+    *,
+    required_capabilities: Sequence[str] = (),
+    timeout: float = 2.0,
+) -> DoctorReport:
+    """Inspect setup, versions, capabilities and connections without launching.
+
+    ``timeout`` bounds each network probe. No build, install, project edit,
+    input acquisition, background log collector or cache write is performed.
+    Inspect ``report.checks`` for actionable failures, or serialize with
+    ``report.as_dict()``. ``ready`` requires a compatible running engine.
+    """
+    from .diagnostics import inspect_project
+    return inspect_project(project_path, required_capabilities=required_capabilities, timeout=timeout)
+
+
+def install_python(project_path: Union[str, Path] = ".") -> Path:
+    """Seed the project's Python wrapper from its already-fetched dependency.
+
+    No editor or network connection is required. Fetch Libraries first, then
+    run this helper from an extension checkout or the standalone install.py.
+    It atomically replaces the complete managed automation-bridge-python
+    directory; keep project scripts elsewhere and restart Python afterward.
+    The dependency URL and other project settings remain unchanged.
+    """
+    root = Path(project_path).expanduser().resolve()
+    dependency = _bridge_dependency(_read_project_configuration(root))
+    destination = root / _AUTOMATION_BRIDGE_PYTHON_DIRECTORY
+    if destination.is_symlink() or (destination.exists() and not destination.is_dir()):
+        raise AutomationBridgeUpdateError(f"refusing to replace non-directory Python wrapper path: {destination}")
+    _replace_python_wrapper(_automation_bridge_archive_path(root, dependency), destination)
+    return destination
+
+
 def open_project(
     root: Union[str, Path] = ".",
     *,
@@ -1431,6 +1486,8 @@ __all__ = [
     "ConsoleSnapshot",
     "ConsoleStream",
     "Debugger",
+    "DiagnosticCheck",
+    "DoctorReport",
     "Error",
     "FetchLibrariesResult",
     "HttpError",
@@ -1448,6 +1505,8 @@ __all__ = [
     "SourceRange",
     "UnsupportedOperationError",
     "installation_registry_path",
+    "install_python",
+    "doctor",
     "installations",
     "is_running",
     "latest_installation",

--- a/automation_bridge/automation-bridge-python/automation_bridge/editor.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/editor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import configparser
 import hashlib
 import json
+import math
 import os
 import re
 import shutil
@@ -23,7 +24,7 @@ from typing import Any, Iterator, Mapping, Optional, Sequence, TYPE_CHECKING, Un
 
 from .client import AutomationBridgeError, HttpError, request_json, request_raw
 from .preferences import PreferenceKey, Preferences
-from .waits import wait_until
+from .waits import WaitTimeoutError, wait_until
 
 if TYPE_CHECKING:
     from .client import Client as EngineClient
@@ -33,6 +34,7 @@ _AUTOMATION_BRIDGE_ENDPOINT_TEXT = "Automation Bridge endpoint registered"
 _AUTOMATION_BRIDGE_REPOSITORY = "https://github.com/defold/extension-automation-bridge"
 _AUTOMATION_BRIDGE_LATEST_RELEASE_API = "https://api.github.com/repos/defold/extension-automation-bridge/releases/latest"
 _AUTOMATION_BRIDGE_PYTHON_DIRECTORY = "automation-bridge-python"
+_EDITOR_ABSENCE_GRACE_PERIOD = 5.0
 _DEPENDENCY_LINE_PATTERN = re.compile(r"^(\s*dependencies#(\d+)\s*=\s*)(.*?)([ \t]*(?:\r\n|\n|\r)?)$")
 _SECTION_PATTERN = re.compile(r"^\s*\[([^]]+)\]\s*(?:\r\n|\n|\r)?$")
 _ENGINE_SERVICE_PORT_PATTERNS = (
@@ -602,10 +604,7 @@ class Client:
     def __init__(self, root: Union[str, Path], port: Optional[int] = None):
         self.root = Path(root).resolve()
         if port is None:
-            port_path = self.root / ".internal" / "editor.port"
-            if not port_path.exists():
-                raise FileNotFoundError(f"Defold editor port file is missing: {port_path}")
-            port = int(port_path.read_text(encoding="utf-8").strip())
+            port = self._read_editor_port(self.root)
         self.port = int(port)
         self.base_url = f"http://127.0.0.1:{self.port}"
         self._engine_service_port: Optional[int] = self._read_cached_engine_service_port()
@@ -620,6 +619,13 @@ class Client:
         self.reference = Reference(self)
         self.preview = Preview(self)
         self.preferences = Preferences(self)
+
+    @staticmethod
+    def _read_editor_port(project_root: Path) -> int:
+        port_path = project_root / ".internal" / "editor.port"
+        if not port_path.exists():
+            raise FileNotFoundError(f"Defold editor port file is missing: {port_path}")
+        return int(port_path.read_text(encoding="utf-8").strip())
 
     def update_automation_bridge(
         self,
@@ -722,16 +728,22 @@ class Client:
         launcher: Optional[Union[str, Path]] = None,
     ) -> "Client":
         """Connect to this project's editor, launching Defold when necessary."""
+        timeout = float(timeout)
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise ValueError("timeout must be finite and greater than zero")
         project_root = Path(root).resolve()
         try:
-            client = cls(project_root)
-        except (FileNotFoundError, ValueError):
-            client = None
-        if client is not None and client._is_running(timeout=min(1.0, timeout)):
+            client = cls._wait_for_editor(
+                project_root,
+                timeout=timeout,
+                allow_absent=start_if_needed,
+                message=f"Could not connect to Defold editor for {project_root}",
+            )
+        except WaitTimeoutError as exc:
+            raise NotRunningError(str(exc)) from exc
+        if client is not None:
             client._record_lifecycle("editor_reused", port=client.port)
             return client
-        if not start_if_needed:
-            raise NotRunningError(f"Defold editor is not running for {project_root}")
 
         project_file = project_root / "game.project"
         if not project_file.is_file():
@@ -757,20 +769,12 @@ class Client:
         except OSError as exc:
             raise LaunchError(f"cannot launch Defold from {launcher_path}: {exc}") from exc
 
-        def ready() -> Optional["Client"]:
-            try:
-                candidate = cls(project_root)
-                return candidate if candidate._is_running(timeout=min(1.0, timeout)) else None
-            except (AutomationBridgeError, FileNotFoundError, OSError, ValueError):
-                return None
-
-        client = wait_until(
-            ready,
+        client = cls._wait_for_editor(
+            project_root,
             timeout=timeout,
-            interval=0.1,
             message=f"Defold editor did not start for {project_root}",
-            retry_exceptions=(AutomationBridgeError,),
         )
+        assert client is not None
         client._record_lifecycle(
             "editor_started",
             launcher=str(launcher_path),
@@ -778,6 +782,72 @@ class Client:
             port=client.port,
         )
         return client
+
+    @classmethod
+    def _wait_for_editor(
+        cls,
+        project_root: Path,
+        *,
+        timeout: float,
+        message: str,
+        allow_absent: bool = False,
+    ) -> Optional["Client"]:
+        """Wait for discovery; return None after consistent evidence of absence."""
+        started = time.monotonic()
+        deadline = started + timeout
+        absence_deadline = started + min(_EDITOR_ABSENCE_GRACE_PERIOD, timeout)
+        absent = object()
+        last_refused_port = None
+        unresolved_error = None
+
+        def ready():
+            nonlocal last_refused_port, unresolved_error
+            port = None
+            try:
+                # The editor can publish or replace its port while we wait.
+                port = cls._read_editor_port(project_root)
+                candidate = cls(project_root, port=port)
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    if allow_absent and unresolved_error is None and port == last_refused_port:
+                        return absent
+                    return None
+                candidate._check_connection(timeout=remaining)
+                return candidate
+            except (FileNotFoundError, ValueError) as exc:
+                failure = exc
+                if port is not None:
+                    unresolved_error = exc
+            except HttpError as exc:
+                failure = exc
+                cause = exc.__cause__
+                if isinstance(cause, urllib.error.URLError):
+                    cause = cause.reason
+                # Only a refused connection establishes that nobody is listening.
+                # A timeout, denied connection, or HTTP error may be a live editor.
+                if isinstance(cause, ConnectionRefusedError):
+                    last_refused_port = port
+                else:
+                    unresolved_error = exc
+            except OSError as exc:
+                failure = exc
+                unresolved_error = exc
+            # Keep the failure that prevents a launch, even if later probes only
+            # observe a missing file or a refused connection.
+            if unresolved_error is not None:
+                raise unresolved_error
+            if allow_absent and time.monotonic() >= absence_deadline:
+                return absent
+            raise failure
+
+        result = wait_until(
+            ready,
+            timeout=timeout,
+            interval=0.1,
+            message=message,
+            retry_exceptions=(HttpError, OSError, ValueError),
+        )
+        return None if result is absent else result
 
     @classmethod
     def _installations(cls) -> list[Installation]:
@@ -838,19 +908,22 @@ class Client:
     def _is_running(self, timeout: float = 1.0) -> bool:
         """Return whether this project's recorded editor port serves the editor API."""
         try:
-            status, document = request_json(f"{self.base_url}/openapi.json", timeout=timeout)
-            if 200 <= status < 300:
-                self._openapi_document = document
-            return 200 <= status < 300
+            self._check_connection(timeout=timeout)
+            return True
         except AutomationBridgeError:
             return False
 
+    def _check_connection(self, *, timeout: float) -> None:
+        """Fetch the editor API, preserving the cause of failed discovery."""
+        url = f"{self.base_url}/openapi.json"
+        status, document = request_json(url, timeout=timeout)
+        if status < 200 or status >= 300:
+            raise HttpError("GET", url, f"HTTP {status}: {document}", status=status)
+        self._openapi_document = document
+
     def _openapi(self) -> dict:
         if self._openapi_document is None:
-            status, document = request_json(f"{self.base_url}/openapi.json", timeout=10.0)
-            if status < 200 or status >= 300:
-                raise HttpError("GET", f"{self.base_url}/openapi.json", str(document), status=status)
-            self._openapi_document = document
+            self._check_connection(timeout=10.0)
         return self._openapi_document
 
     def _require_operation(self, path: str, method: str) -> Mapping[str, Any]:
@@ -1298,7 +1371,7 @@ class Client:
 
 
 def is_running(root: Union[str, Path] = ".", *, timeout: float = 1.0) -> bool:
-    """Return whether the project's recorded editor endpoint is healthy."""
+    """Check the recorded editor endpoint once; use open_project for retries."""
     try:
         return Client(root)._is_running(timeout=timeout)
     except (AutomationBridgeError, FileNotFoundError, OSError, ValueError):
@@ -1312,7 +1385,19 @@ def open_project(
     timeout: float = 30.0,
     launcher: Optional[Union[str, Path]] = None,
 ) -> Client:
-    """Open or reuse a Defold editor for one project."""
+    """Open or reuse a Defold editor for one project.
+
+    Discovery retries for up to ``timeout`` seconds, rereading the port file
+    between attempts. Each HTTP request can use the remaining discovery time.
+    ``timeout`` must be finite and greater than zero.
+
+    With ``start_if_needed=True``, a missing/invalid port file or refused
+    connection gets up to five seconds (bounded by ``timeout``) to recover
+    before launching Defold. Startup then has its own ``timeout`` budget.
+    Other connection failures are retried for the full discovery timeout and
+    raise ``NotRunningError`` with diagnostics instead of launching a duplicate.
+    ``start_if_needed=False`` always waits for discovery without launching.
+    """
     return Client._open_project(
         root,
         start_if_needed=start_if_needed,

--- a/automation_bridge/automation-bridge-python/automation_bridge/editor.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/editor.py
@@ -981,7 +981,15 @@ class Client:
         *,
         timeout: float = 20.0,
         required_capabilities: Sequence[str] = (),
+        client_id: Optional[str] = None,
+        session_id: Optional[str] = None,
     ) -> EngineClient:
+        """Attach to the registered engine without taking lifecycle ownership.
+
+        Explicit client/session IDs let one logical automation session reconnect.
+        Use distinct IDs for independent agents; the native input lease remains
+        exclusive. Closing the client leaves the engine running.
+        """
         from .client import Client as EngineClient
 
         return EngineClient._from_editor(
@@ -989,14 +997,25 @@ class Client:
             build_command=None,
             timeout=timeout,
             required_capabilities=required_capabilities,
+            client_id=client_id,
+            session_id=session_id,
         )
+
 
     def build_and_run(
         self,
         *,
         timeout: float = 60.0,
         required_capabilities: Sequence[str] = (),
+        client_id: Optional[str] = None,
+        session_id: Optional[str] = None,
     ) -> EngineClient:
+        """Build a new engine and return a client with owns_engine=True.
+
+        Explicit client/session IDs let one logical automation session reconnect.
+        Use distinct IDs for independent agents; the native input lease remains
+        exclusive. Closing the client leaves the engine running.
+        """
         from .client import Client as EngineClient
 
         return EngineClient._from_editor(
@@ -1004,14 +1023,25 @@ class Client:
             build_command="build",
             timeout=timeout,
             required_capabilities=required_capabilities,
+            client_id=client_id,
+            session_id=session_id,
         )
+
 
     def clean_build_and_run(
         self,
         *,
         timeout: float = 60.0,
         required_capabilities: Sequence[str] = (),
+        client_id: Optional[str] = None,
+        session_id: Optional[str] = None,
     ) -> EngineClient:
+        """Build a new engine and return a client with owns_engine=True.
+
+        Explicit client/session IDs let one logical automation session reconnect.
+        Use distinct IDs for independent agents; the native input lease remains
+        exclusive. Closing the client leaves the engine running.
+        """
         from .client import Client as EngineClient
 
         return EngineClient._from_editor(
@@ -1019,7 +1049,10 @@ class Client:
             build_command="clean-build",
             timeout=timeout,
             required_capabilities=required_capabilities,
+            client_id=client_id,
+            session_id=session_id,
         )
+
 
     def build_and_run_html5(self, *, timeout: float = 60.0) -> None:
         self._empty_command("build-html5", timeout)

--- a/automation_bridge/automation-bridge-python/automation_bridge/editor.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/editor.py
@@ -1452,8 +1452,8 @@ def doctor(
     return inspect_project(project_path, required_capabilities=required_capabilities, timeout=timeout)
 
 
-def install_python(project_path: Union[str, Path] = ".") -> Path:
-    """Seed the project's Python wrapper from its already-fetched dependency.
+def update_python_wrapper(project_path: Union[str, Path] = ".") -> Path:
+    """Update the project's Python wrapper from its already-fetched dependency.
 
     No editor or network connection is required. Fetch Libraries first, then
     run this helper from an extension checkout or the standalone install.py.
@@ -1542,10 +1542,10 @@ __all__ = [
     "SourceRange",
     "UnsupportedOperationError",
     "installation_registry_path",
-    "install_python",
     "doctor",
     "installations",
     "is_running",
     "latest_installation",
     "open_project",
+    "update_python_wrapper",
 ]

--- a/automation_bridge/automation-bridge-python/automation_bridge/editor.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/editor.py
@@ -26,6 +26,7 @@ from .client import AutomationBridgeError, HttpError, request_json, request_raw
 from .preferences import PreferenceKey, Preferences
 from .waits import WaitTimeoutError, wait_until
 from .diagnostics import DiagnosticCheck, DoctorReport
+from .cancellation import cancellable_sleep, check_cancelled
 
 if TYPE_CHECKING:
     from .client import Client as EngineClient
@@ -748,6 +749,7 @@ class Client:
         launcher: Optional[Union[str, Path]] = None,
     ) -> "Client":
         """Connect to this project's editor, launching Defold when necessary."""
+        check_cancelled()
         timeout = float(timeout)
         if not math.isfinite(timeout) or timeout <= 0:
             raise ValueError("timeout must be finite and greater than zero")
@@ -966,6 +968,7 @@ class Client:
             raise UnsupportedOperationError(f"editor does not advertise command {command!r}")
 
     def _empty_command(self, command: str, timeout: float) -> None:
+        check_cancelled()
         self._require_command(command)
         url = f"{self.base_url}/command/{command}"
         status, body = request_raw(url, method="POST", timeout=timeout)
@@ -1059,6 +1062,7 @@ class Client:
 
     def _build_and_run_command(self, command: str, timeout: float = 60.0) -> None:
         """Execute a desktop build-and-run command and await endpoint registration."""
+        check_cancelled()
         if command not in {"build", "clean-build"}:
             raise ValueError(f"unsupported desktop build-and-run command: {command}")
         self._require_command(command)
@@ -1095,7 +1099,7 @@ class Client:
             raise AutomationBridgeError(str(exc)) from exc
         self._record_lifecycle("new_engine_registered")
         self._last_build_had_engine_service_port = self._latest_registration_has_engine_service_port()
-        time.sleep(0.2)
+        cancellable_sleep(0.2)
 
     def _console_lines(self) -> list:
         """Return current editor console lines."""

--- a/automation_bridge/automation-bridge-python/automation_bridge/elements.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/elements.py
@@ -1,7 +1,87 @@
 """Typed snapshot wrappers for Automation Bridge scene elements."""
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, TypedDict, Union
+
+
+class ElementSelector(TypedDict, total=False):
+    """Supported keyword filters for element queries and waits.
+
+    ``type``, ``name``, ``text`` and ``url`` match substrings, ignoring case
+    unless ``case_sensitive=True``. Their ``*_exact`` variants, identity fields,
+    paths and application annotations use case-sensitive exact matching.
+    ``limit`` is 0..500 (default 50); zero requests only counts. ``cursor`` is
+    the opaque string returned by a page and takes precedence over ``offset``.
+    Pages are live snapshots, not a frozen traversal across multiple requests.
+    """
+
+    id: str
+    instance_id: str
+    logical_id: str
+    type: str
+    type_exact: str
+    name: str
+    name_exact: str
+    text: str
+    text_exact: str
+    url: str
+    url_exact: str
+    path: str
+    kind: str
+    automation_id: str
+    localization_key: str
+    role: str
+    enabled: bool
+    has_bounds: bool
+    visible_and_enabled: bool
+    visible: bool
+    case_sensitive: bool
+    include: Union[str, Iterable[str]]
+    limit: int
+    offset: int
+    cursor: str
+
+
+@dataclass(frozen=True)
+class ElementPage:
+    """One native query result, including pagination and snapshot evidence.
+
+    Pass ``next_cursor`` into the next query with the same filters. Re-query
+    after scene changes; cursors do not pin a snapshot. ``raw`` retains native
+    diagnostics such as active collections and excluded matches.
+    """
+
+    elements: Tuple["Element", ...]
+    matched: int
+    total: int
+    offset: int
+    next_cursor: Optional[str]
+    truncated: bool
+    scene_sequence: int
+    engine_frame: int
+    raw: Mapping[str, Any]
+
+    @classmethod
+    def from_raw(cls, data: Mapping[str, Any]) -> "ElementPage":
+        """Wrap a native /elements data object without dropping its metadata."""
+        elements = tuple(Element(item) for item in data.get("elements", ()) if isinstance(item, dict))
+        cursor = data.get("next_cursor")
+        return cls(
+            elements=elements,
+            matched=int(data.get("matched", len(elements))),
+            total=int(data.get("total", len(elements))),
+            offset=int(data.get("offset", 0)),
+            next_cursor=str(cursor) if cursor is not None else None,
+            truncated=bool(data.get("truncated", False)),
+            scene_sequence=int(data.get("scene_sequence", 0)),
+            engine_frame=int(data.get("engine_frame", 0)),
+            raw=dict(data),
+        )
+
+    @property
+    def count(self) -> int:
+        """Return the number of elements in this page, not the total matches."""
+        return len(self.elements)
 
 
 @dataclass(frozen=True)

--- a/automation_bridge/automation-bridge-python/automation_bridge/engine.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/engine.py
@@ -18,7 +18,7 @@ from .client import (
     UnsupportedCapabilityError,
 )
 from .events import CommandTimeout, Event, EventBufferOverflow, EventStream, StateSnapshot
-from .elements import Bounds, Element
+from .elements import Bounds, Element, ElementPage, ElementSelector
 from .profiler import *  # Re-export the focused profiler result and control types.
 from .recording import (
     VideoRecordingCapabilities,

--- a/automation_bridge/automation-bridge-python/automation_bridge/engine.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/engine.py
@@ -32,6 +32,7 @@ from .receipts import ObservationReceipt, ScreenshotReceipt
 from .trace import TraceSession
 from .visual import VisualObservation
 from .waits import WaitTimeoutError, wait_until
+from .cancellation import CancellationToken, OperationCancelled, cancellation_scope
 
 
 def connect(

--- a/automation_bridge/automation-bridge-python/automation_bridge/engine.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/engine.py
@@ -18,6 +18,7 @@ from .client import (
     UnsupportedCapabilityError,
 )
 from .events import CommandTimeout, Event, EventBufferOverflow, EventStream, StateSnapshot
+from .application import ApplicationCatalogPage, ApplicationEntry
 from .elements import Bounds, Element, ElementPage, ElementSelector
 from .profiler import *  # Re-export the focused profiler result and control types.
 from .recording import (

--- a/automation_bridge/automation-bridge-python/automation_bridge/events.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/events.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from typing import Any, List, Mapping, Optional, TYPE_CHECKING, Union
+from .cancellation import cancellation_active, check_cancelled
 
 if TYPE_CHECKING:
     from .client import Client
@@ -111,6 +112,7 @@ class EventStream:
 
     def poll(self, timeout: float = 0.0, limit: int = 100) -> List[Event]:
         """Long-poll once and advance the cursor after all returned events."""
+        check_cancelled()
         if self._closed:
             raise RuntimeError("event stream is closed")
         if timeout < 0:
@@ -118,6 +120,8 @@ class EventStream:
         if limit < 1 or limit > 256:
             raise ValueError("limit must be between 1 and 256")
         safe_wait = min(timeout, max(0.0, float(self.client.timeout) - 0.1), 30.0)
+        if cancellation_active():
+            safe_wait = min(safe_wait, 0.1)
         data = self.client.request(
             "GET", "/events",
             params={"cursor": self.cursor, "timeout_ms": int(safe_wait * 1000), "limit": limit},
@@ -143,6 +147,7 @@ class EventStream:
 
         deadline = time.monotonic() + timeout
         while True:
+            check_cancelled()
             for index, event in enumerate(self._pending):
                 if event.name == name and (event_type is None or event.type == event_type) and _mapping_contains(event.data, where):
                     return self._pending.pop(index)

--- a/automation_bridge/automation-bridge-python/automation_bridge/metal.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/metal.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, Mapping, Optional, Union
 
 from .waits import wait_until
+from .cancellation import OperationCancelled, check_cancelled
 
 
 class MetalCaptureError(RuntimeError):
@@ -71,6 +72,7 @@ class MetalCaptureClient:
         The running engine must use the Metal graphics adapter and must have
         been launched with ``METAL_CAPTURE_ENABLED=1``.
         """
+        check_cancelled()
         if isinstance(frames, bool) or not isinstance(frames, int) or not 1 <= frames <= 10000:
             raise ValueError("frames must be an integer from 1 through 10000")
         if wait and timeout < 0:
@@ -99,12 +101,19 @@ class MetalCaptureClient:
                 raise MetalCaptureError(capture.error or "Metal GPU trace capture failed")
             return capture if capture.terminal else None
 
-        capture = wait_until(
-            terminal,
-            timeout=timeout,
-            interval=interval,
-            message="Metal GPU trace capture did not finish",
-        )
+        try:
+            capture = wait_until(
+                terminal,
+                timeout=timeout,
+                interval=interval,
+                message="Metal GPU trace capture did not finish",
+            )
+        except OperationCancelled as exc:
+            try:
+                self.stop(wait=False)
+            except Exception as cleanup_error:
+                exc.cleanup_error = cleanup_error
+            raise
         self.bridge._trace_record("metal_capture_finished", capture.to_dict())
         return capture
 

--- a/automation_bridge/automation-bridge-python/automation_bridge/remotery.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/remotery.py
@@ -10,6 +10,7 @@ import socket
 import struct
 import threading
 import time
+from .cancellation import check_cancelled
 import urllib.parse
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterator, List, Mapping, Optional, Sequence, Set, Tuple, Union
@@ -838,6 +839,7 @@ class RemoteryClient:
         """
         deadline = _deadline(self.timeout if timeout is None else timeout)
         while True:
+            check_cancelled()
             message_id, body = self._next_message(deadline)
             if message_id != "SMPL":
                 continue
@@ -898,6 +900,7 @@ class RemoteryClient:
         """Read and return one profiler property/counter snapshot."""
         deadline = _deadline(self.timeout if timeout is None else timeout)
         while True:
+            check_cancelled()
             message_id, body = self._next_message(deadline)
             if message_id != "PSNP":
                 continue
@@ -928,6 +931,7 @@ class RemoteryClient:
         property_frames: List[RemoteryPropertyFrame] = []
 
         while len(sample_frames) < frames:
+            check_cancelled()
             message_id, body = self._next_message(deadline)
             if message_id == "SMPL":
                 frame = parse_sample_frame(body, self._sample_names)

--- a/automation_bridge/automation-bridge-python/automation_bridge/waits.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/waits.py
@@ -3,6 +3,8 @@
 import time
 from typing import Any, Callable, Mapping, Optional, Tuple, Type, TypeVar, Union
 
+from .cancellation import OperationCancelled, cancellable_sleep, check_cancelled
+
 
 T = TypeVar("T")
 RetryExceptions = Union[Type[BaseException], Tuple[Type[BaseException], ...]]
@@ -60,6 +62,7 @@ def wait_until(
     callback for clients that track it from native responses. ``predicate``
     can define success independently of truthiness so waits for values such as
     zero still retain the actual observation in timeout diagnostics.
+    An active ``engine.cancellation_scope(token)`` interrupts polling and delays.
     """
     retry_types = _normalize_retry_exceptions(retry_exceptions)
     if timeout < 0:
@@ -75,9 +78,11 @@ def wait_until(
     attempts = 0
 
     while True:
+        check_cancelled()
         attempts += 1
         try:
             last_value = fn()
+            check_cancelled()
             inferred_sequence = _sequence_from_value(last_value)
             last_scene_sequence = (
                 inferred_sequence
@@ -87,6 +92,8 @@ def wait_until(
             succeeded = predicate(last_value) if predicate is not None else bool(last_value)
             if succeeded:
                 return last_value
+        except OperationCancelled:
+            raise
         except retry_types as exc:
             last_error = exc
             last_scene_sequence = _read_scene_sequence(scene_sequence, last_scene_sequence)
@@ -105,7 +112,7 @@ def wait_until(
             if last_error is not None:
                 raise error from last_error
             raise error
-        time.sleep(min(interval, max(0.0, deadline - now)))
+        cancellable_sleep(min(interval, max(0.0, deadline - now)))
 
 
 def _normalize_retry_exceptions(value: RetryExceptions) -> Tuple[Type[BaseException], ...]:

--- a/automation_bridge/automation-bridge-python/best_practices.py
+++ b/automation_bridge/automation-bridge-python/best_practices.py
@@ -31,6 +31,14 @@ from automation_bridge import editor, engine
 ProjectPath = Union[str, Path]
 
 
+def diagnose_project(project_root: ProjectPath = ".") -> editor.DoctorReport:
+    """Inspect setup without launching or building, and retain actionable errors."""
+    report = editor.doctor(project_root, required_capabilities=("elements",))
+    for check in report.checks:
+        print(check.name, check.status, check.message, check.action or "")
+    return report
+
+
 def update_bridge(
     project: editor.Client,
     version: Optional[str] = None,

--- a/automation_bridge/automation-bridge-python/best_practices.py
+++ b/automation_bridge/automation-bridge-python/best_practices.py
@@ -307,6 +307,8 @@ def close_owned_game(game: engine.Client, owns_engine: bool) -> None:
     """Do not terminate a reused engine merely because a script is finished."""
     if owns_engine:
         game.close_engine()
+    else:
+        game.close()
 
 
 if __name__ == "__main__":

--- a/automation_bridge/automation-bridge-python/install.py
+++ b/automation_bridge/automation-bridge-python/install.py
@@ -1,4 +1,4 @@
-"""Install a project's fetched Python wrapper without configuring PYTHONPATH."""
+"""Update a project's fetched Python wrapper without configuring PYTHONPATH."""
 
 import argparse
 from automation_bridge import editor
@@ -9,9 +9,9 @@ def main() -> None:
     parser.add_argument("project_path", help="Defold project directory; Fetch Libraries first")
     args = parser.parse_args()
     try:
-        print(editor.install_python(args.project_path))
+        print(editor.update_python_wrapper(args.project_path))
     except (editor.Error, OSError, ValueError) as exc:
-        parser.exit(1, f"Cannot install Automation Bridge Python: {exc}\n")
+        parser.exit(1, f"Cannot update Automation Bridge Python wrapper: {exc}\n")
 
 
 if __name__ == "__main__":

--- a/automation_bridge/automation-bridge-python/install.py
+++ b/automation_bridge/automation-bridge-python/install.py
@@ -1,0 +1,18 @@
+"""Install a project's fetched Python wrapper without configuring PYTHONPATH."""
+
+import argparse
+from automation_bridge import editor
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project_path", help="Defold project directory; Fetch Libraries first")
+    args = parser.parse_args()
+    try:
+        print(editor.install_python(args.project_path))
+    except (editor.Error, OSError, ValueError) as exc:
+        parser.exit(1, f"Cannot install Automation Bridge Python: {exc}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/automation_bridge/src/automation_bridge_application.cpp
+++ b/automation_bridge/src/automation_bridge_application.cpp
@@ -224,6 +224,24 @@ namespace dmAutomationBridge
         memset(state, 0, sizeof(*state));
     }
 
+    static void FreeApplicationContract(ApplicationContract* contract)
+    {
+        FreeString(&contract->m_Kind);
+        FreeString(&contract->m_Name);
+        FreeString(&contract->m_MetadataJson);
+    }
+
+    // Caller holds m_ApplicationMutex for all catalog reads and mutations.
+    static ApplicationContract* FindApplicationContract(const char* kind, const char* name)
+    {
+        for (uint32_t i = 0; i < g_AutomationBridge.m_ApplicationContracts.m_Count; ++i)
+        {
+            ApplicationContract* contract = &g_AutomationBridge.m_ApplicationContracts.m_Data[i];
+            if (StringsEqual(contract->m_Kind, kind) && StringsEqual(contract->m_Name, name)) return contract;
+        }
+        return 0;
+    }
+
     static void FreeCommandInvocation(CommandInvocation* command)
     {
         FreeString(&command->m_Name);
@@ -249,6 +267,7 @@ namespace dmAutomationBridge
         g_AutomationBridge.m_NextEventSequence = 1;
         g_AutomationBridge.m_NextStateRevision = 1;
         g_AutomationBridge.m_NextCommandId = 1;
+        g_AutomationBridge.m_CatalogRevision = 0;
         g_AutomationBridge.m_ApplicationMutex = dmMutex::New();
         if (IsEmpty(g_AutomationBridge.m_EngineInstanceId))
         {
@@ -258,6 +277,8 @@ namespace dmAutomationBridge
 
     void FinalizeApplicationLua()
     {
+        if (!g_AutomationBridge.m_ApplicationMutex) return;
+        dmMutex::ScopedLock lock(g_AutomationBridge.m_ApplicationMutex);
         for (uint32_t i = 0; i < g_AutomationBridge.m_CommandHandlers.m_Count; ++i)
         {
             CommandHandler* handler = &g_AutomationBridge.m_CommandHandlers.m_Data[i];
@@ -269,6 +290,10 @@ namespace dmAutomationBridge
             FreeString(&handler->m_Name);
         }
         ArrayFree(&g_AutomationBridge.m_CommandHandlers);
+        for (uint32_t i = 0; i < g_AutomationBridge.m_ApplicationContracts.m_Count; ++i)
+            FreeApplicationContract(&g_AutomationBridge.m_ApplicationContracts.m_Data[i]);
+        ArrayFree(&g_AutomationBridge.m_ApplicationContracts);
+        ++g_AutomationBridge.m_CatalogRevision;
     }
 
     void FreeApplicationBridge()
@@ -416,6 +441,7 @@ namespace dmAutomationBridge
                     return false;
                 }
                 state = &g_AutomationBridge.m_PublishedStates.m_Data[g_AutomationBridge.m_PublishedStates.m_Count - 1];
+                ++g_AutomationBridge.m_CatalogRevision;
             }
             if (!SetString(&state->m_ValueJson, value_json)) return false;
             state->m_Revision = g_AutomationBridge.m_NextStateRevision++;
@@ -471,6 +497,56 @@ namespace dmAutomationBridge
             if (StringsEqual(g_AutomationBridge.m_CommandHandlers.m_Data[i].m_Name, name)) return &g_AutomationBridge.m_CommandHandlers.m_Data[i];
         }
         return 0;
+    }
+
+    static void AppendCatalogEntry(StringBuffer* out, const char* kind, const char* name,
+                                   const char* filter_kind, const char* filter_name,
+                                   uint32_t offset, uint32_t limit, uint32_t* matched, uint32_t* count)
+    {
+        if (filter_kind && !StringsEqual(kind, filter_kind)) return;
+        if (filter_name && !StringsEqual(name, filter_name)) return;
+        uint32_t index = (*matched)++;
+        if (index < offset || *count >= limit) return;
+        ApplicationContract* contract = FindApplicationContract(kind, name);
+        if ((*count)++) StringBufferAppendChar(out, ',');
+        StringBufferAppend(out, "{\"kind\":"); AppendJsonString(out, kind);
+        StringBufferAppend(out, ",\"name\":"); AppendJsonString(out, name);
+        StringBufferAppend(out, ",\"contract\":");
+        StringBufferAppend(out, contract ? contract->m_MetadataJson : "{}");
+        StringBufferAppendChar(out, '}');
+    }
+
+    void AppendApplicationCatalogJson(StringBuffer* out, const char* kind, const char* name, uint32_t offset, uint32_t limit)
+    {
+        dmMutex::ScopedLock lock(g_AutomationBridge.m_ApplicationMutex);
+        uint32_t matched = 0;
+        uint32_t count = 0;
+        StringBufferAppend(out, "{\"entries\":[");
+        for (uint32_t i = 0; i < g_AutomationBridge.m_CommandHandlers.m_Count; ++i)
+            AppendCatalogEntry(out, "command", g_AutomationBridge.m_CommandHandlers.m_Data[i].m_Name, kind, name, offset, limit, &matched, &count);
+        for (uint32_t i = 0; i < g_AutomationBridge.m_PublishedStates.m_Count; ++i)
+            AppendCatalogEntry(out, "state", g_AutomationBridge.m_PublishedStates.m_Data[i].m_Name, kind, name, offset, limit, &matched, &count);
+        for (uint32_t i = 0; i < g_AutomationBridge.m_ApplicationContracts.m_Count; ++i)
+        {
+            const ApplicationContract* contract = &g_AutomationBridge.m_ApplicationContracts.m_Data[i];
+            if (StringsEqual(contract->m_Kind, "command")) continue;
+            if (StringsEqual(contract->m_Kind, "state") && FindPublishedState(contract->m_Name)) continue;
+            AppendCatalogEntry(out, contract->m_Kind, contract->m_Name, kind, name, offset, limit, &matched, &count);
+        }
+        StringBufferAppend(out, "],\"count\":"); AppendNumber(out, count);
+        StringBufferAppend(out, ",\"matched\":"); AppendNumber(out, matched);
+        StringBufferAppend(out, ",\"offset\":"); AppendNumber(out, offset);
+        StringBufferAppend(out, ",\"next_cursor\":");
+        if (count && (uint64_t)offset + count < matched)
+        {
+            char cursor[32];
+            dmSnPrintf(cursor, sizeof(cursor), "%llu", (unsigned long long)offset + count);
+            AppendJsonString(out, cursor);
+        }
+        else StringBufferAppend(out, "null");
+        StringBufferAppend(out, ",\"revision\":"); AppendNumber(out, (double)g_AutomationBridge.m_CatalogRevision);
+        StringBufferAppend(out, ",\"engine_instance_id\":"); AppendJsonString(out, g_AutomationBridge.m_EngineInstanceId);
+        StringBufferAppendChar(out, '}');
     }
 
     static CommandInvocation* FindCommandInvocation(uint64_t id)
@@ -802,6 +878,127 @@ namespace dmAutomationBridge
         return 0;
     }
 
+    static bool IsLuaObject(lua_State* L, int index)
+    {
+        if (!lua_istable(L, index)) return false;
+        if (index < 0) index += lua_gettop(L) + 1;
+        lua_pushnil(L);
+        while (lua_next(L, index))
+        {
+            if (lua_type(L, -2) != LUA_TSTRING || lua_objlen(L, -2) != strlen(lua_tostring(L, -2)))
+            {
+                lua_pop(L, 2);
+                return false;
+            }
+            lua_pop(L, 1);
+        }
+        return true;
+    }
+
+    static bool ValidateApplicationContract(lua_State* L, const char* kind)
+    {
+        if (!IsLuaObject(L, 3)) return false;
+        lua_pushnil(L);
+        while (lua_next(L, 3))
+        {
+            const char* key = lua_tostring(L, -2);
+            bool valid = false;
+            if (StringsEqual(key, "description"))
+                valid = lua_type(L, -1) == LUA_TSTRING && lua_objlen(L, -1) > 0 && lua_objlen(L, -1) <= 4096;
+            else if (StringsEqual(kind, "command") ? (StringsEqual(key, "input_schema") || StringsEqual(key, "output_schema")) : StringsEqual(key, "schema"))
+                valid = lua_isboolean(L, -1) || IsLuaObject(L, -1);
+            if (!valid)
+            {
+                lua_pop(L, 2);
+                return false;
+            }
+            lua_pop(L, 1);
+        }
+        return true;
+    }
+
+    static bool StoreApplicationContract(const char* kind, const char* name, const char* json, const char** error)
+    {
+        dmMutex::ScopedLock lock(g_AutomationBridge.m_ApplicationMutex);
+        if (StringsEqual(kind, "command") && !FindCommandHandler(name))
+        {
+            *error = "register the command before describing it";
+            return false;
+        }
+        ApplicationContract* existing = FindApplicationContract(kind, name);
+        if (existing)
+        {
+            if (!SetString(&existing->m_MetadataJson, json)) { *error = "out of memory"; return false; }
+        }
+        else
+        {
+            if (g_AutomationBridge.m_ApplicationContracts.m_Count >= 256)
+            {
+                *error = "at most 256 application contracts can be declared";
+                return false;
+            }
+            ApplicationContract contract;
+            contract.m_Kind = DuplicateString(kind);
+            contract.m_Name = DuplicateString(name);
+            contract.m_MetadataJson = DuplicateString(json);
+            if (!contract.m_Kind || !contract.m_Name || !contract.m_MetadataJson || !ArrayPush(&g_AutomationBridge.m_ApplicationContracts, &contract))
+            {
+                FreeApplicationContract(&contract);
+                *error = "out of memory";
+                return false;
+            }
+        }
+        ++g_AutomationBridge.m_CatalogRevision;
+        return true;
+    }
+
+    static int LuaDescribe(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        luaL_checktype(L, 1, LUA_TSTRING);
+        luaL_checktype(L, 2, LUA_TSTRING);
+        luaL_checktype(L, 3, LUA_TTABLE);
+        const char* kind = lua_tostring(L, 1);
+        const char* name = lua_tostring(L, 2);
+        if (lua_objlen(L, 1) != strlen(kind) || !(StringsEqual(kind, "command") || StringsEqual(kind, "state") || StringsEqual(kind, "event")))
+            return luaL_error(L, "kind must be command, state, or event");
+        if (lua_objlen(L, 2) != strlen(name) || !IsValidApplicationName(name, false))
+            return luaL_error(L, "contract name must be an identifier such as app.ready");
+        if (!ValidateApplicationContract(L, kind))
+            return luaL_error(L, "contract fields must be description (1-4096 bytes) and schema objects or booleans; commands use input_schema/output_schema, states/events use schema");
+        char* json = 0;
+        const char* error = 0;
+        if (!EncodeLuaJson(L, 3, &json, &error)) return luaL_error(L, "%s", error);
+        bool ok = StoreApplicationContract(kind, name, json, &error);
+        free(json);
+        if (!ok) return luaL_error(L, "%s", error);
+        return 0;
+    }
+
+    static bool RegisterCommandCallback(const char* name, dmScript::LuaCallbackInfo* callback)
+    {
+        dmMutex::ScopedLock lock(g_AutomationBridge.m_ApplicationMutex);
+        CommandHandler* handler = FindCommandHandler(name);
+        if (handler)
+        {
+            dmScript::DestroyCallback(handler->m_Callback);
+            handler->m_Callback = callback;
+        }
+        else
+        {
+            CommandHandler new_handler;
+            new_handler.m_Name = DuplicateString(name);
+            new_handler.m_Callback = callback;
+            if (!new_handler.m_Name || !ArrayPush(&g_AutomationBridge.m_CommandHandlers, &new_handler))
+            {
+                free(new_handler.m_Name);
+                return false;
+            }
+        }
+        ++g_AutomationBridge.m_CatalogRevision;
+        return true;
+    }
+
     static int LuaCommand(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
@@ -811,20 +1008,8 @@ namespace dmAutomationBridge
         if (!IsValidApplicationName(name, false)) return luaL_error(L, "command name must be an identifier, preferably namespaced such as app.load_fixture");
         dmScript::LuaCallbackInfo* callback = dmScript::CreateCallback(L, 2);
         if (!callback) return luaL_error(L, "command callback must be registered from a script instance");
-        dmMutex::ScopedLock lock(g_AutomationBridge.m_ApplicationMutex);
-        CommandHandler* handler = FindCommandHandler(name);
-        if (handler)
+        if (!RegisterCommandCallback(name, callback))
         {
-            dmScript::DestroyCallback(handler->m_Callback);
-            handler->m_Callback = callback;
-            return 0;
-        }
-        CommandHandler new_handler;
-        new_handler.m_Name = DuplicateString(name);
-        new_handler.m_Callback = callback;
-        if (!new_handler.m_Name || !ArrayPush(&g_AutomationBridge.m_CommandHandlers, &new_handler))
-        {
-            free(new_handler.m_Name);
             dmScript::DestroyCallback(callback);
             return luaL_error(L, "failed to retain command callback");
         }
@@ -909,6 +1094,7 @@ namespace dmAutomationBridge
             {"emit", LuaEmit},
             {"publish", LuaPublish},
             {"command", LuaCommand},
+            {"describe", LuaDescribe},
             {"acknowledge_input", LuaAcknowledgeInput},
             {"annotate", LuaAnnotate},
             {0, 0}

--- a/automation_bridge/src/automation_bridge_http.cpp
+++ b/automation_bridge/src/automation_bridge_http.cpp
@@ -5,6 +5,7 @@
 #if defined(DM_DEBUG)
 
 #include <ctype.h>
+#include <errno.h>
 #include <limits.h>
 #include <string.h>
 
@@ -551,8 +552,9 @@ namespace dmAutomationBridge
         }
 
         char* end = 0;
+        errno = 0;
         unsigned long parsed = strtoul(text, &end, 10);
-        if (!end || *end != 0 || parsed == 0 || parsed > (unsigned long)max_value)
+        if (errno == ERANGE || !end || *end != 0 || parsed == 0 || parsed > (unsigned long)max_value)
         {
             return false;
         }
@@ -569,8 +571,9 @@ namespace dmAutomationBridge
             return false;
         }
         char* end = 0;
+        errno = 0;
         unsigned long parsed = strtoul(text, &end, 10);
-        if (!end || *end != 0 || parsed > (unsigned long)max_value)
+        if (errno == ERANGE || !end || *end != 0 || parsed > (unsigned long)max_value)
         {
             return false;
         }
@@ -587,8 +590,9 @@ namespace dmAutomationBridge
             return false;
         }
         char* end = 0;
+        errno = 0;
         unsigned long long parsed = strtoull(text, &end, 10);
-        if (!end || *end != 0 || parsed > max_value || (!allow_zero && parsed == 0))
+        if (errno == ERANGE || !end || *end != 0 || parsed > max_value || (!allow_zero && parsed == 0))
         {
             return false;
         }

--- a/automation_bridge/src/automation_bridge_http.cpp
+++ b/automation_bridge/src/automation_bridge_http.cpp
@@ -792,6 +792,7 @@ namespace dmAutomationBridge
             AppendCapability(&names, &versions, &first, "application.events");
             AppendCapability(&names, &versions, &first, "application.state");
             AppendCapability(&names, &versions, &first, "application.commands");
+            AppendCapability(&names, &versions, &first, "application.catalog");
             AppendCapability(&names, &versions, &first, "application.acknowledgements");
             AppendCapability(&names, &versions, &first, "application.annotations");
         }
@@ -2455,6 +2456,44 @@ namespace dmAutomationBridge
         RequestSendJson(ctx, 200, &response);
     }
 
+    static void HandleApplicationCatalog(RequestContext* ctx)
+    {
+        if (!g_AutomationBridge.m_ApplicationApiEnabled)
+        {
+            RequestSendError(ctx, 501, "unsupported_capability", "application.catalog requires application_api = 1");
+            return;
+        }
+        const char* kind = RequestGetParam(ctx, "kind");
+        const char* name = RequestGetParam(ctx, "name");
+        if (kind && !(StringsEqual(kind, "command") || StringsEqual(kind, "state") || StringsEqual(kind, "event")))
+        {
+            RequestSendError(ctx, 400, "bad_request", "kind must be command, state, or event");
+            return;
+        }
+        if (name && (IsEmpty(name) || strlen(name) > MAX_APPLICATION_NAME_BYTES))
+        {
+            RequestSendError(ctx, 400, "bad_request", "name must be a non-empty application identifier");
+            return;
+        }
+        uint32_t limit = 50;
+        uint32_t offset = 0;
+        uint32_t cursor = 0;
+        if ((RequestGetParam(ctx, "limit") && !RequestGetUIntParamAllowZero(ctx, "limit", &limit, 100)) ||
+            (RequestGetParam(ctx, "offset") && !RequestGetUIntParamAllowZero(ctx, "offset", &offset)) ||
+            (RequestGetParam(ctx, "cursor") && !RequestGetUIntParamAllowZero(ctx, "cursor", &cursor)))
+        {
+            RequestSendError(ctx, 400, "bad_request", "limit must be 0-100; offset and cursor must be unsigned 32-bit integers");
+            return;
+        }
+        if (RequestGetParam(ctx, "cursor")) offset = cursor;
+        StringBuffer response;
+        StringBufferInit(&response);
+        StringBufferAppend(&response, "{\"ok\":true,\"data\":");
+        AppendApplicationCatalogJson(&response, kind, name, offset, limit);
+        StringBufferAppend(&response, "}\n");
+        RequestSendJson(ctx, 200, &response);
+    }
+
     static void HandleState(RequestContext* ctx)
     {
         StringBuffer page;
@@ -2794,6 +2833,7 @@ namespace dmAutomationBridge
         {"/events/cursor", "GET", HandleEventCursor},
         {"/events", "GET", HandleEvents},
         {"/state", "GET", HandleState},
+        {"/application/catalog", "GET", HandleApplicationCatalog},
         {"/state/wait", "GET", HandleStateWait},
         {"/commands", "POST", HandleCommandSubmit},
         {"/commands", "GET", HandleCommandStatus},

--- a/automation_bridge/src/automation_bridge_http.cpp
+++ b/automation_bridge/src/automation_bridge_http.cpp
@@ -1215,12 +1215,20 @@ namespace dmAutomationBridge
 
         IncludeOptions include = ParseInclude(ctx, false, false);
         uint32_t limit = 50;
-        RequestGetUIntParamAllowZero(ctx, "limit", &limit, 500);
-        uint32_t offset = 0;
-        if (!RequestGetUIntParamAllowZero(ctx, "cursor", &offset))
+        if (RequestGetParam(ctx, "limit") && !RequestGetUIntParamAllowZero(ctx, "limit", &limit, 500))
         {
-            RequestGetUIntParamAllowZero(ctx, "offset", &offset);
+            RequestSendError(ctx, 400, "bad_request", "limit must be an integer between 0 and 500");
+            return;
         }
+        uint32_t offset = 0;
+        uint32_t cursor = 0;
+        if ((RequestGetParam(ctx, "offset") && !RequestGetUIntParamAllowZero(ctx, "offset", &offset)) ||
+            (RequestGetParam(ctx, "cursor") && !RequestGetUIntParamAllowZero(ctx, "cursor", &cursor)))
+        {
+            RequestSendError(ctx, 400, "bad_request", "offset and cursor must be unsigned integers");
+            return;
+        }
+        if (RequestGetParam(ctx, "cursor")) offset = cursor;
 
         const Snapshot* snapshot = &g_AutomationBridge.m_Snapshot;
         uint32_t matched = 0;

--- a/automation_bridge/src/automation_bridge_private.h
+++ b/automation_bridge/src/automation_bridge_private.h
@@ -305,6 +305,13 @@ namespace dmAutomationBridge
         dmScript::LuaCallbackInfo* m_Callback;
     };
 
+    struct ApplicationContract
+    {
+        char* m_Kind;
+        char* m_Name;
+        char* m_MetadataJson;
+    };
+
     enum CommandState
     {
         COMMAND_PENDING,
@@ -376,6 +383,8 @@ namespace dmAutomationBridge
         Array<BridgeEvent>      m_Events;
         Array<PublishedState>   m_PublishedStates;
         Array<CommandHandler>   m_CommandHandlers;
+        Array<ApplicationContract> m_ApplicationContracts;
+        uint64_t                m_CatalogRevision;
         Array<CommandInvocation> m_CommandInvocations;
         Array<NodeAnnotation>   m_NodeAnnotations;
         uint32_t                m_EventCapacity;
@@ -618,6 +627,7 @@ namespace dmAutomationBridge
     uint32_t AppendEventPageJson(StringBuffer* out, uint64_t cursor, uint32_t limit, bool* overflow, uint64_t* next_cursor);
     uint64_t GetStateRevision();
     uint32_t AppendPublishedStatesJson(StringBuffer* out, const char* name, uint64_t after_revision);
+    void AppendApplicationCatalogJson(StringBuffer* out, const char* kind, const char* name, uint32_t offset, uint32_t limit);
     bool SubmitCommand(const char* name, const char* arguments_json, uint32_t timeout_ms, uint64_t* command_id, const char** error);
     bool AppendCommandJson(StringBuffer* out, uint64_t command_id);
     bool CancelCommand(uint64_t command_id, const char** error);

--- a/examples/application_sync.script
+++ b/examples/application_sync.script
@@ -12,6 +12,20 @@ function init(self)
         return { loaded = data.name }
     end)
 
+    automation_bridge.describe("command", "example.load_fixture", {
+        description = "Load a named fixture and emit example.fixture_loaded.",
+        input_schema = { type = "object", properties = { name = { type = "string" } }, required = { "name" } },
+        output_schema = { type = "object", properties = { loaded = { type = "string" } }, required = { "loaded" } },
+    })
+    automation_bridge.describe("state", "example.ui", {
+        description = "Current workflow state; a busy value of false permits input.",
+        schema = { type = "object", properties = { busy = { type = "boolean" }, workflow_step = { type = "string" } } },
+    })
+    automation_bridge.describe("event", "example.fixture_loaded", {
+        description = "Emitted once a requested fixture is ready.",
+        schema = { type = "object", properties = { name = { type = "string" } }, required = { "name" } },
+    })
+
     automation_bridge.annotate("main:/ui#status", {
         automation_id = "operation_status",
         localization_key = "status_ready",

--- a/game.project
+++ b/game.project
@@ -15,6 +15,7 @@ input_method = HiddenInputField
 [automation_bridge]
 application_api = 1
 event_capacity = 256
+test_contracts = 1
 
 [physics]
 gravity_y = -1000.0

--- a/main/controller.script
+++ b/main/controller.script
@@ -197,6 +197,9 @@ function init(self)
 			schema = { type = "object", properties = { request_id = { type = "string" } } },
 		})
 		publish_automation_state()
+		if sys.get_config_int("automation_bridge.test_contracts", 0) == 1 then
+			require("tests.application_contracts").register(function() return items end, item_bounds)
+		end
 	end
 end
 

--- a/main/controller.script
+++ b/main/controller.script
@@ -183,6 +183,19 @@ function init(self)
 			})
 			return { reset = true }
 		end)
+		automation_bridge.describe("command", "sample.reset", {
+			description = "Remove all items and close the win popup.",
+			input_schema = { type = "object", properties = { request_id = { type = "string" } } },
+			output_schema = { type = "object", properties = { reset = { type = "boolean" } }, required = { "reset" } },
+		})
+		automation_bridge.describe("state", "sample.game", {
+			description = "Current game status; published after reset, spawn, and merge.",
+			schema = { type = "object", properties = { busy = { type = "boolean" }, item_count = { type = "integer" } }, required = { "busy", "item_count" } },
+		})
+		automation_bridge.describe("event", "sample.reset_complete", {
+			description = "Emitted after reset with the caller's optional request_id.",
+			schema = { type = "object", properties = { request_id = { type = "string" } } },
+		})
 		publish_automation_state()
 	end
 end

--- a/tests/application_contracts.lua
+++ b/tests/application_contracts.lua
@@ -1,0 +1,63 @@
+-- Opt-in fixtures for the sample project's native application catalog tests.
+local M = {}
+
+function M.register(current_items, item_bounds)
+    automation_bridge.command("sample.arrange_items", function(data)
+        -- Native input tests need separated targets clear of the SPAWN button.
+        -- Keep randomized placement and motion in the interactive sample.
+        local items = current_items()
+        local ids = {}
+        for id in pairs(items) do ids[#ids + 1] = id end
+        table.sort(ids, function(a, b) return tostring(a) < tostring(b) end)
+        local min_x, max_x, min_y, max_y = item_bounds()
+        local columns = 3
+        local rows = math.max(1, math.ceil(#ids / columns))
+        for index, id in ipairs(ids) do
+            local column = (index - 1) % columns
+            local row = math.floor((index - 1) / columns)
+            local x = min_x + (max_x - min_x) * (0.55 + 0.35 * column / (columns - 1))
+            local y = min_y + (max_y - min_y) * (0.25 + 0.5 * row / math.max(1, rows - 1))
+            items[id].pos = vmath.vector3(x, y, items[id].pos.z)
+            items[id].velocity = vmath.vector3()
+            go.set_position(items[id].pos, id)
+        end
+        return { arranged = #ids }
+    end)
+    automation_bridge.command("sample.catalog_probe", function(data)
+        return { available = true }
+    end)
+    automation_bridge.describe("state", "sample.future", { description = "First declaration", schema = true })
+    automation_bridge.describe("state", "sample.future", { description = "Replacement declaration", schema = false })
+
+    local deep = { type = "object" }
+    for _ = 1, 20 do
+        deep = { properties = { child = deep } }
+    end
+    local invalid = {
+        { "unknown", "sample.future", {} },
+        { "state", "invalid name", {} },
+        { "command", "sample.unregistered", { description = "Missing callback" } },
+        { "state", "sample.future", { description = "" } },
+        { "state", "sample.future", { description = 5 } },
+        { "state", "sample.future", { description = string.rep("x", 4097) } },
+        { "state", "sample.future", { schema = "object" } },
+        { "state", "sample.future", { schema = { 1, 2 } } },
+        { "state", "sample.future", { input_schema = {} } },
+        { "command", "sample.catalog_probe", { schema = {} } },
+        { "state", "sample.future", { unknown = true } },
+        { "state", "sample.future", { schema = { description = string.rep("x", 32769) } } },
+        { "state", "sample.future", { schema = deep } },
+    }
+    local rejected = {}
+    for index, args in ipairs(invalid) do
+        local ok = pcall(automation_bridge.describe, unpack(args))
+        rejected[index] = not ok
+    end
+    automation_bridge.publish("sample.contract_checks", { rejected = rejected })
+    automation_bridge.command("sample.catalog_reject", function(data)
+        local ok = pcall(automation_bridge.describe, "state", "sample.future", { unknown = true })
+        return { rejected = not ok }
+    end)
+end
+
+return M

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -168,6 +168,40 @@ def _count_light_pixels_in_rect(path, rect):
 
 
 class EngineClientUnitTest(unittest.TestCase):
+    def test_application_catalog_retains_contracts_and_pagination(self):
+        bridge = EngineClient(12345)
+        bridge._last_health = {"capabilities": ["application.catalog"]}
+        response = {
+            "entries": [{"kind": "command", "name": "test.reset", "contract": {
+                "description": "Reset the test.", "input_schema": False, "output_schema": {"type": "object"},
+            }}],
+            "count": 1, "matched": 3, "offset": 1, "next_cursor": "2",
+            "revision": 7, "engine_instance_id": "engine:test",
+        }
+        with mock.patch.object(bridge, "_request", return_value=response) as request:
+            page = bridge.application_catalog(kind="command", limit=1, cursor="1")
+        self.assertIsInstance(page, engine.ApplicationCatalogPage)
+        self.assertEqual((1, 3, 1, "2", 7, "engine:test"), (page.count, page.matched, page.offset, page.next_cursor, page.revision, page.engine_instance_id))
+        self.assertEqual("Reset the test.", page.entries[0].description)
+        self.assertIs(False, page.entries[0].input_schema)
+        self.assertEqual({"type": "object"}, page.entries[0].output_schema)
+        self.assertIsNone(page.entries[0].schema)
+        self.assertEqual("/application/catalog", request.call_args.args[1])
+        self.assertEqual("1", request.call_args.args[2]["cursor"])
+
+    def test_application_catalog_requires_capability_before_query(self):
+        bridge = FakeEngineClient()
+        with self.assertRaises(UnsupportedCapabilityError):
+            bridge.application_catalog()
+        self.assertEqual(["/health"], [path for _, path, _ in bridge.api_requests])
+
+    def test_application_catalog_rejects_malformed_filters_before_io(self):
+        bridge = EngineClient(12345)
+        for options in ({"kind": "commands"}, {"name": ""}, {"name": 5}, {"name": "a" * 129}, {"limit": True}, {"limit": 101}, {"offset": -1}, {"cursor": 1}, {"cursor": "x"}):
+            with self.subTest(options=options), mock.patch.object(bridge, "_request") as request:
+                with self.assertRaises((TypeError, ValueError)):
+                    bridge.application_catalog(**options)
+                request.assert_not_called()
     def test_cancellation_interrupts_long_poll_delay_from_another_thread(self):
         token = engine.CancellationToken()
         observed = threading.Event()
@@ -3527,6 +3561,26 @@ class AutomationBridgeApiTest(unittest.TestCase):
         for params in ({"limit": "invalid"}, {"limit": 501}, {"cursor": "invalid"}, {"offset": -1}):
             with self.subTest(params=params), self.assertRaises(AutomationBridgeApiError) as error:
                 self.bridge.request("GET", "/elements", params=params)
+            self.assertEqual(400, error.exception.status)
+
+    def test_application_catalog_discovers_command_and_state_event_contracts(self):
+        self.ensure_running_bridge()
+        command = self.bridge.application_catalog(kind="command", name="sample.reset")
+        self.assertEqual(1, command.matched)
+        self.assertIn("Remove all items", command.entries[0].description)
+        self.assertEqual("string", command.entries[0].input_schema["properties"]["request_id"]["type"])
+        state = self.bridge.application_catalog(kind="state", name="sample.game")
+        self.assertEqual("integer", state.entries[0].schema["properties"]["item_count"]["type"])
+        event = self.bridge.application_catalog(kind="event", name="sample.reset_complete")
+        self.assertEqual("object", event.entries[0].schema["type"])
+        first = self.bridge.application_catalog(limit=1)
+        second = self.bridge.application_catalog(limit=1, cursor=first.next_cursor)
+        self.assertEqual((first.revision, first.engine_instance_id), (second.revision, second.engine_instance_id))
+        self.assertNotEqual(first.entries[0].name, second.entries[0].name)
+        self.assertEqual(0, self.bridge.application_catalog(limit=0).count)
+        for params in ({"kind": "unknown"}, {"name": ""}, {"limit": "invalid"}, {"limit": 101}, {"offset": -1}, {"cursor": ""}):
+            with self.subTest(params=params), self.assertRaises(AutomationBridgeApiError) as error:
+                self.bridge.request("GET", "/application/catalog", params=params)
             self.assertEqual(400, error.exception.status)
 
     def test_session_ownership_and_detach_leave_engine_available(self):

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -459,7 +459,7 @@ class EngineClientUnitTest(unittest.TestCase):
         write.assert_not_called()
         collect.assert_not_called()
 
-    def test_install_python_uses_fetched_archive_without_editing_project(self):
+    def test_update_python_wrapper_uses_fetched_archive_without_editing_project(self):
         dependency = "https://github.com/defold/extension-automation-bridge/archive/refs/tags/2.1.0.zip"
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -467,12 +467,12 @@ class EngineClientUnitTest(unittest.TestCase):
             (root / "game.project").write_text(content)
             self._write_automation_bridge_archive(root, dependency)
             with mock.patch.object(editor, "open_project") as launch:
-                path = editor.install_python(root)
+                path = editor.update_python_wrapper(root)
             self.assertEqual("new", (path / "automation_bridge" / "__init__.py").read_text())
             self.assertEqual(content, (root / "game.project").read_text())
         launch.assert_not_called()
 
-    def test_install_python_rejects_ambiguous_dependencies_and_preserves_wrapper(self):
+    def test_update_python_wrapper_rejects_ambiguous_dependencies_and_preserves_wrapper(self):
         dependency = "https://github.com/defold/extension-automation-bridge/archive/refs/tags/2.1.0.zip"
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -482,7 +482,7 @@ class EngineClientUnitTest(unittest.TestCase):
             marker = wrapper / "existing.py"
             marker.write_text("original")
             with self.assertRaisesRegex(editor.AutomationBridgeUpdateError, "ambiguous"):
-                editor.install_python(root)
+                editor.update_python_wrapper(root)
             self.assertEqual("original", marker.read_text())
 
     def test_public_surface_excludes_removed_aliases_and_backend_types(self):

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -1231,7 +1231,7 @@ class EngineClientUnitTest(unittest.TestCase):
 
             with mock.patch("automation_bridge.editor.sys.platform", "linux"):
                 with mock.patch("automation_bridge.editor.subprocess.Popen", side_effect=launch) as popen:
-                    with mock.patch.object(EditorApiClient, "_is_running", return_value=True):
+                    with mock.patch.object(EditorApiClient, "_check_connection", return_value=None):
                         editor_client = editor.open_project(root, launcher=launcher, timeout=0.2)
 
         self.assertEqual(54321, editor_client.port)
@@ -2518,6 +2518,258 @@ class EngineClientUnitTest(unittest.TestCase):
             )
 
 
+class EditorDiscoveryUnitTest(unittest.TestCase):
+    def setUp(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.root = Path(directory.name).resolve()
+        (self.root / ".internal").mkdir()
+        self.port_file = self.root / ".internal" / "editor.port"
+        self.port_file.write_text("12345", encoding="utf-8")
+        (self.root / "game.project").write_text("[project]\ntitle = Test\n", encoding="utf-8")
+        self.launcher = self.root / "Defold"
+        self.launcher.touch()
+        self.now = 0.0
+        self._patch("automation_bridge.editor.time.monotonic", side_effect=lambda: self.now)
+        self.sleep = self._patch("automation_bridge.editor.time.sleep", side_effect=self._advance)
+        self._patch("automation_bridge.editor._macos_gui_launch_is_sandboxed", return_value=False)
+        self.popen = self._patch(
+            "automation_bridge.editor.subprocess.Popen",
+            side_effect=AssertionError("unexpected editor launch"),
+        )
+        self.response = mock.MagicMock()
+        self.response.__enter__.return_value = self.response
+        self.response.getcode.return_value = 200
+        self.response.read.return_value = b'{"openapi":"3.0.3"}'
+        self.urlopen = self._patch(
+            "automation_bridge.client.urllib.request.urlopen",
+            return_value=self.response,
+        )
+
+    def _patch(self, target, **kwargs):
+        patcher = mock.patch(target, **kwargs)
+        result = patcher.start()
+        self.addCleanup(patcher.stop)
+        return result
+
+    def _advance(self, seconds):
+        self.now += seconds
+
+    def _slow_response(self, request, *, timeout):
+        delay = 1.2
+        self._advance(min(delay, timeout))
+        if timeout < delay:
+            raise TimeoutError("timed out")
+        return self.response
+
+    def _launch(self, *args, **kwargs):
+        self.port_file.write_text("54321", encoding="utf-8")
+        self.urlopen.side_effect = None
+        return mock.Mock(pid=4321)
+
+    def test_slow_editor_is_reused_with_supplied_timeout(self):
+        self.urlopen.side_effect = self._slow_response
+
+        project = editor.open_project(self.root, timeout=5, launcher=self.launcher)
+
+        self.assertEqual(12345, project.port)
+        self.assertEqual("editor_reused", project.lifecycle_events[-1]["stage"])
+        self.assertAlmostEqual(1.2, self.now)
+        self.popen.assert_not_called()
+
+    def test_transient_failures_recover_on_third_attempt_without_launching(self):
+        self.urlopen.side_effect = [
+            urllib.error.URLError(ConnectionRefusedError("not listening yet")),
+            ConnectionResetError("connection reset"),
+            self.response,
+        ]
+
+        project = editor.open_project(self.root, timeout=5, launcher=self.launcher)
+
+        self.assertEqual(12345, project.port)
+        self.assertEqual(3, self.urlopen.call_count)
+        self.popen.assert_not_called()
+
+    def test_missing_or_partial_port_file_can_appear_during_discovery(self):
+        for initial in (None, "", "writing"):
+            for start_if_needed in (False, True):
+                with self.subTest(initial=initial, start_if_needed=start_if_needed):
+                    self.now = 0.0
+                    if initial is None:
+                        self.port_file.unlink()
+                    else:
+                        self.port_file.write_text(initial, encoding="utf-8")
+
+                    def publish_port(seconds):
+                        self._advance(seconds)
+                        if self.now >= 4.0:
+                            self.port_file.write_text("54321", encoding="utf-8")
+
+                    self.sleep.side_effect = publish_port
+                    project = editor.open_project(
+                        self.root,
+                        start_if_needed=start_if_needed,
+                        timeout=5,
+                        launcher=self.launcher,
+                    )
+
+                    self.assertEqual(54321, project.port)
+                    self.assertEqual("editor_reused", project.lifecycle_events[-1]["stage"])
+                    self.popen.assert_not_called()
+
+    def test_port_is_reread_after_a_failed_request(self):
+        def replace_port(request, *, timeout):
+            self.port_file.write_text("54321", encoding="utf-8")
+            self.urlopen.side_effect = None
+            raise urllib.error.URLError(ConnectionRefusedError("old port closed"))
+
+        self.urlopen.side_effect = replace_port
+        project = editor.open_project(self.root, timeout=5, launcher=self.launcher)
+
+        self.assertEqual(54321, project.port)
+        urls = [call.args[0].full_url for call in self.urlopen.call_args_list]
+        self.assertEqual([
+            "http://127.0.0.1:12345/openapi.json",
+            "http://127.0.0.1:54321/openapi.json",
+        ], urls)
+        self.popen.assert_not_called()
+
+    def test_timeout_preserves_cause_and_does_not_launch(self):
+        failure = TimeoutError("editor response timed out")
+
+        def never_respond(request, *, timeout):
+            self._advance(timeout)
+            raise failure
+
+        self.urlopen.side_effect = never_respond
+        with self.assertRaisesRegex(editor.NotRunningError, "editor response timed out") as raised:
+            editor.open_project(self.root, timeout=5, launcher=self.launcher)
+
+        self.assertAlmostEqual(5, self.now)
+        self.assertIn("http://127.0.0.1:12345/openapi.json", str(raised.exception))
+        wait_error = raised.exception.__cause__
+        self.assertIs(failure, wait_error.last_exception.__cause__)
+        self.popen.assert_not_called()
+
+    def test_denied_connection_never_launches_even_if_later_refused(self):
+        attempts = 0
+
+        def unavailable(request, *, timeout):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise urllib.error.URLError(PermissionError("connection denied"))
+            raise urllib.error.URLError(ConnectionRefusedError("connection refused"))
+
+        self.urlopen.side_effect = unavailable
+        with self.assertRaisesRegex(editor.NotRunningError, "connection denied"):
+            editor.open_project(self.root, timeout=5, launcher=self.launcher)
+
+        self.assertAlmostEqual(5, self.now)
+        self.popen.assert_not_called()
+
+    def test_http_and_json_errors_keep_diagnostics_without_launching(self):
+        for status, body, detail in (
+            (503, b'{"error":"busy"}', "HTTP 503"),
+            (403, b'{"error":"denied"}', "HTTP 403"),
+            (200, b"not JSON", "invalid JSON response"),
+        ):
+            with self.subTest(status=status, body=body):
+                self.now = 0.0
+                self.response.getcode.return_value = status
+                self.response.read.return_value = body
+                with self.assertRaisesRegex(editor.NotRunningError, detail):
+                    editor.open_project(self.root, timeout=5, launcher=self.launcher)
+                self.assertAlmostEqual(5, self.now)
+                self.popen.assert_not_called()
+
+    def test_unreadable_port_file_keeps_diagnostics_without_launching(self):
+        with mock.patch.object(Path, "read_text", side_effect=PermissionError("port file denied")):
+            with self.assertRaisesRegex(editor.NotRunningError, "port file denied"):
+                editor.open_project(self.root, timeout=5, launcher=self.launcher)
+
+        self.urlopen.assert_not_called()
+        self.popen.assert_not_called()
+
+    def test_invalid_engine_cache_is_not_mistaken_for_an_absent_editor(self):
+        cache = self.root / ".internal" / "automation_bridge.remotery.url"
+        cache.write_bytes(b"\xff")
+        with self.assertRaisesRegex(editor.NotRunningError, "utf-8"):
+            editor.open_project(self.root, timeout=5, launcher=self.launcher)
+        self.popen.assert_not_called()
+
+    def test_missing_editor_launches_once_after_grace_period(self):
+        self.port_file.unlink()
+        self.popen.side_effect = self._launch
+
+        project = editor.open_project(self.root, timeout=30, launcher=self.launcher)
+
+        self.assertEqual(54321, project.port)
+        self.assertEqual("editor_started", project.lifecycle_events[-1]["stage"])
+        self.assertGreaterEqual(self.now, 5)
+        self.assertLess(self.now, 6)
+        self.popen.assert_called_once()
+
+    def test_refused_stale_port_can_launch_with_a_short_timeout(self):
+        self.urlopen.side_effect = urllib.error.URLError(ConnectionRefusedError("stale port"))
+        self.popen.side_effect = self._launch
+
+        project = editor.open_project(self.root, timeout=0.2, launcher=self.launcher)
+
+        self.assertEqual(54321, project.port)
+        self.popen.assert_called_once()
+
+    def test_no_start_waits_for_the_supplied_timeout_when_file_is_missing(self):
+        self.port_file.unlink()
+        with self.assertRaisesRegex(editor.NotRunningError, "editor.port"):
+            editor.open_project(self.root, start_if_needed=False, timeout=5)
+
+        self.assertAlmostEqual(5, self.now)
+        self.popen.assert_not_called()
+
+    def test_started_editor_uses_remaining_startup_timeout_for_slow_reply(self):
+        self.port_file.unlink()
+
+        def launch(*args, **kwargs):
+            process = self._launch(*args, **kwargs)
+            self.urlopen.side_effect = self._slow_response
+            return process
+
+        self.popen.side_effect = launch
+        project = editor.open_project(self.root, timeout=2, launcher=self.launcher)
+
+        self.assertEqual(54321, project.port)
+        self.assertAlmostEqual(3.2, self.now)
+        self.popen.assert_called_once()
+
+    def test_startup_failure_preserves_diagnostics_and_does_not_launch_again(self):
+        self.port_file.unlink()
+
+        def launch(*args, **kwargs):
+            process = self._launch(*args, **kwargs)
+            self.urlopen.side_effect = urllib.error.URLError(ConnectionRefusedError("not ready"))
+            return process
+
+        self.popen.side_effect = launch
+        with self.assertRaisesRegex(WaitTimeoutError, "not ready"):
+            editor.open_project(self.root, timeout=0.2, launcher=self.launcher)
+        self.popen.assert_called_once()
+
+    def test_invalid_timeout_fails_before_discovery_or_launch(self):
+        for timeout in (0, -1, float("inf"), float("nan")):
+            with self.subTest(timeout=timeout):
+                with self.assertRaisesRegex(ValueError, "timeout must be finite and greater than zero"):
+                    editor.open_project(self.root, timeout=timeout, launcher=self.launcher)
+        self.urlopen.assert_not_called()
+        self.popen.assert_not_called()
+
+    def test_is_running_remains_a_single_boolean_probe(self):
+        self.urlopen.side_effect = TimeoutError("timed out")
+        self.assertFalse(editor.is_running(self.root, timeout=2))
+        self.assertEqual(1, self.urlopen.call_count)
+        self.popen.assert_not_called()
+
+
 class FakeEngineClient(EngineClient):
     def __init__(self, screen=None, capabilities=None):
         super().__init__(12345)
@@ -2981,6 +3233,9 @@ class AutomationBridgeApiTest(unittest.TestCase):
             cls.bridge = EngineClient(int(port), profiler_url=remotery_url)
             cls.bridge.wait_ready()
             return
+
+        if not (ROOT / ".internal" / "editor.port").is_file():
+            raise unittest.SkipTest("Defold editor port file is missing")
 
         try:
             cls.editor = editor.open_project(ROOT, start_if_needed=False)

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -168,6 +168,54 @@ def _count_light_pixels_in_rect(path, rect):
 
 
 class EngineClientUnitTest(unittest.TestCase):
+    def test_element_page_retains_cursor_counts_and_snapshot_metadata(self):
+        bridge = EngineClient(1234)
+        bridge._last_health = {"version": "2", "capabilities": ["scene.pagination"]}
+        payload = {"elements": [{"id": "e:1", "logical_id": "i:g1"}], "matched": 8, "total": 12,
+                   "offset": 3, "next_cursor": "4", "truncated": True, "scene_sequence": 7,
+                   "engine_frame": 90, "excluded": {"visibility": 2}}
+        with mock.patch.object(bridge, "_request", return_value=payload) as request:
+            page = bridge.elements_page(type="goc", cursor="3", limit=1)
+        self.assertIsInstance(page, engine.ElementPage)
+        self.assertEqual((1, 8, 12, 3, "4", 7, 90),
+                         (page.count, page.matched, page.total, page.offset, page.next_cursor, page.scene_sequence, page.engine_frame))
+        self.assertEqual("i:g1", page.elements[0].logical_id)
+        self.assertEqual({"visibility": 2}, page.raw["excluded"])
+        self.assertEqual("3", request.call_args.args[2]["cursor"])
+
+    def test_element_page_supports_zero_matches_and_count_only(self):
+        for matched in (0, 20):
+            page = engine.ElementPage.from_raw({"elements": [], "matched": matched, "next_cursor": None})
+            self.assertEqual(matched, page.matched)
+            self.assertEqual(0, page.count)
+            self.assertIsNone(page.next_cursor)
+
+    def test_pagination_cannot_hide_ambiguous_single_element_selector(self):
+        bridge = EngineClient(1234)
+        data = {"elements": [{"id": "e:1"}], "matched": 2, "truncated": True, "next_cursor": "1"}
+        with mock.patch.object(bridge, "_request", return_value=data):
+            for method in (bridge.element, bridge.maybe_element):
+                with self.assertRaises(engine.SelectorError):
+                    method(limit=1)
+        with mock.patch.object(bridge, "_request", return_value={"elements": [], "matched": 1}):
+            with self.assertRaises(engine.SelectorError):
+                bridge.maybe_element(limit=0)
+
+    def test_selector_values_are_validated_before_requesting(self):
+        bridge = EngineClient(1234)
+        with mock.patch.object(bridge, "_request") as request:
+            for selector in ({"limit": -1}, {"limit": 501}, {"limit": True}, {"offset": 0.5},
+                             {"cursor": "bad"}, {"cursor": "4294967296"}, {"visible": "false"}, {"type": 42}):
+                with self.subTest(selector=selector), self.assertRaises((ValueError, TypeError)):
+                    bridge.elements(**selector)
+        request.assert_not_called()
+
+    def test_page_requires_pagination_capability(self):
+        bridge = EngineClient(1234)
+        bridge._last_health = {"version": "2", "capabilities": ["elements"]}
+        with self.assertRaises(engine.UnsupportedCapabilityError):
+            bridge.elements_page()
+
     def test_doctor_reports_invalid_project_without_launching(self):
         with tempfile.TemporaryDirectory() as root, mock.patch.object(editor, "open_project") as open_project:
             report = editor.doctor(root)
@@ -3332,6 +3380,20 @@ class AutomationBridgeApiTest(unittest.TestCase):
     def setUp(self):
         if self.bridge:
             self.reset_if_popup_is_visible()
+
+    def test_pagination_preserves_metadata_and_rejects_invalid_native_values(self):
+        self.ensure_running_bridge()
+        first = self.bridge.elements_page(type="goc", limit=1)
+        self.assertGreater(first.matched, 1)
+        self.assertEqual(1, first.count)
+        second = self.bridge.elements_page(type="goc", limit=1, cursor=first.next_cursor)
+        self.assertEqual(1, second.offset)
+        self.assertNotEqual(first.elements[0].logical_id, second.elements[0].logical_id)
+        self.assertGreaterEqual(second.engine_frame, first.engine_frame)
+        for params in ({"limit": "invalid"}, {"limit": 501}, {"cursor": "invalid"}, {"offset": -1}):
+            with self.subTest(params=params), self.assertRaises(AutomationBridgeApiError) as error:
+                self.bridge.request("GET", "/elements", params=params)
+            self.assertEqual(400, error.exception.status)
 
     def test_automation_bridge_api_end_to_end(self):
         previous_port = None

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -168,6 +168,109 @@ def _count_light_pixels_in_rect(path, rect):
 
 
 class EngineClientUnitTest(unittest.TestCase):
+    def test_cancellation_interrupts_long_poll_delay_from_another_thread(self):
+        token = engine.CancellationToken()
+        observed = threading.Event()
+        errors = []
+
+        def worker():
+            try:
+                with engine.cancellation_scope(token):
+                    wait_until(lambda: observed.set(), timeout=60, interval=60)
+            except engine.OperationCancelled as exc:
+                errors.append(exc)
+
+        thread = threading.Thread(target=worker, daemon=True)
+        thread.start()
+        try:
+            self.assertTrue(observed.wait(2))
+            token.cancel("caller stopped")
+            token.cancel("later reason")
+            thread.join(2)
+            self.assertFalse(thread.is_alive())
+            self.assertEqual(["caller stopped"], [str(exc) for exc in errors])
+        finally:
+            token.cancel()
+            thread.join(2)
+
+    def test_cancellation_is_not_swallowed_by_retry_and_restores_outer_scope(self):
+        outer, inner = engine.CancellationToken(), engine.CancellationToken()
+        with self.assertRaisesRegex(engine.OperationCancelled, "outer"):
+            with engine.cancellation_scope(outer):
+                with self.assertRaisesRegex(engine.OperationCancelled, "inner"):
+                    with engine.cancellation_scope(inner):
+                        wait_until(lambda: inner.cancel("inner"), retry_exceptions=BaseException)
+                self.assertEqual(7, wait_until(lambda: 7))
+                outer.cancel("outer")
+        self.assertEqual(8, wait_until(lambda: 8))
+
+    def test_cancelled_scope_does_not_submit_input_or_launch_editor(self):
+        token = engine.CancellationToken()
+        token.cancel()
+        bridge = FakeInputClient()
+        with mock.patch("automation_bridge.editor.subprocess.Popen") as launch:
+            with self.assertRaises(engine.OperationCancelled):
+                with bridge.cancellation_scope(token):
+                    editor.open_project(".")
+                    bridge.key("SPACE")
+            launch.assert_not_called()
+        self.assertEqual([], bridge.api_requests)
+
+    def test_cancelled_input_wait_requests_native_release(self):
+        bridge = FakeInputClient()
+        token = engine.CancellationToken()
+        with self.assertRaises(engine.OperationCancelled):
+            with engine.cancellation_scope(token):
+                token.cancel()
+                bridge.input.wait(42)
+        self.assertEqual(["/input/cancel"], [path for _, path, _ in bridge.api_requests])
+        self.assertTrue(bridge.api_requests[0][2]["release"])
+
+    def test_client_scope_releases_its_input_when_scene_wait_is_cancelled(self):
+        bridge = FakeInputClient()
+        token = engine.CancellationToken()
+        with self.assertRaises(engine.OperationCancelled):
+            with bridge.cancellation_scope(token):
+                bridge.key("SPACE", hold=1, wait=False)
+                wait_until(lambda: token.cancel())
+        method, path, values = bridge.api_requests[-1]
+        self.assertEqual(("POST", "/input/flush"), (method, path))
+        self.assertEqual(bridge.client_id, values["client_id"])
+        self.assertEqual(bridge.session_id, values["session_id"])
+        self.assertTrue(values["release"])
+
+    def test_command_cancellation_preserves_native_refusal(self):
+        bridge = FakeInputClient()
+        token = engine.CancellationToken()
+        refusal = RuntimeError("running Lua callbacks cannot be preempted")
+        with mock.patch.object(bridge, "cancel_command", side_effect=refusal) as cancel:
+            with self.assertRaises(engine.OperationCancelled) as error:
+                with engine.cancellation_scope(token):
+                    token.cancel()
+                    bridge.wait_for_command(23)
+            cancel.assert_called_once_with(23)
+        self.assertIs(refusal, error.exception.cleanup_error)
+
+    def test_log_cancellation_closes_idle_socket(self):
+        token = engine.CancellationToken()
+        stream = EngineLogStream.__new__(EngineLogStream)
+        sock = mock.Mock()
+        sock.gettimeout.return_value = None
+        stream._socket = sock
+        stream._buffer = bytearray()
+
+        def receive(_):
+            token.cancel()
+            raise socket.timeout()
+
+        sock.recv.side_effect = receive
+        with self.assertRaises(engine.OperationCancelled):
+            with engine.cancellation_scope(token):
+                stream.readline()
+        self.assertTrue(stream.closed)
+        sock.close.assert_called_once()
+        sock.settimeout.assert_called_once_with(0.1)
+
     def test_editor_workflows_forward_explicit_session_identity(self):
         project = EditorApiClient(".", port=1234)
         with mock.patch.object(EngineClient, "_from_editor") as connect:
@@ -3433,6 +3536,22 @@ class AutomationBridgeApiTest(unittest.TestCase):
         attached.close()
         self.assertTrue(attached.closed)
         self.assertEqual(self.bridge.engine_instance_id, self.bridge.health()["engine_instance_id"])
+
+    def test_cancellation_releases_held_native_input(self):
+        self.ensure_running_bridge()
+        token = engine.CancellationToken()
+        with self.assertRaises(engine.OperationCancelled):
+            with self.bridge.cancellation_scope(token):
+                held = self.bridge.key("SPACE", hold=5, wait="started")
+                token.cancel("stop held input")
+                wait_until(lambda: False)
+        receipt = wait_until(
+            lambda: self.bridge.input.status(held.input_id),
+            predicate=lambda item: item.state in {"cancelled", "released"},
+            timeout=2,
+        )
+        self.assertLess(receipt["actual_duration"], 4)
+        self.assertEqual("released", self.bridge.key("SPACE", wait="released").state)
 
     def test_automation_bridge_api_end_to_end(self):
         previous_port = None

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -168,6 +168,37 @@ def _count_light_pixels_in_rect(path, rect):
 
 
 class EngineClientUnitTest(unittest.TestCase):
+    def test_editor_workflows_forward_explicit_session_identity(self):
+        project = EditorApiClient(".", port=1234)
+        with mock.patch.object(EngineClient, "_from_editor") as connect:
+            for method in (project.connect_engine, project.build_and_run, project.clean_build_and_run):
+                method(client_id="agent-a", session_id="task-1")
+                self.assertEqual("agent-a", connect.call_args.kwargs["client_id"])
+                self.assertEqual("task-1", connect.call_args.kwargs["session_id"])
+
+    def test_client_close_releases_local_resources_without_native_mutations(self):
+        bridge = EngineClient(1234, client_id="agent-a", session_id="task-1")
+        with mock.patch.object(bridge._logs, "close") as close, \
+             mock.patch.object(bridge, "_post_engine_message") as post:
+            with bridge:
+                self.assertFalse(bridge.owns_engine)
+                self.assertFalse(bridge.closed)
+                self.assertEqual("task-1", bridge.session_info()["session_id"])
+            bridge.close()
+        close.assert_called_once()
+        post.assert_not_called()
+        self.assertTrue(bridge.closed)
+        with self.assertRaisesRegex(AutomationBridgeError, "closed"):
+            bridge.health()
+
+    def test_invalid_session_identity_is_rejected_before_build(self):
+        project = EditorApiClient(".", port=1234)
+        with mock.patch.object(project, "_build_and_run_command") as build:
+            for value in (False, "", 1):
+                with self.subTest(value=value), self.assertRaises(ValueError):
+                    project.build_and_run(session_id=value)
+        build.assert_not_called()
+
     def test_element_page_retains_cursor_counts_and_snapshot_metadata(self):
         bridge = EngineClient(1234)
         bridge._last_health = {"version": "2", "capabilities": ["scene.pagination"]}
@@ -3394,6 +3425,14 @@ class AutomationBridgeApiTest(unittest.TestCase):
             with self.subTest(params=params), self.assertRaises(AutomationBridgeApiError) as error:
                 self.bridge.request("GET", "/elements", params=params)
             self.assertEqual(400, error.exception.status)
+
+    def test_session_ownership_and_detach_leave_engine_available(self):
+        self.ensure_running_bridge()
+        attached = engine.connect(self.bridge.port, client_id="observer", session_id="detach-test")
+        self.assertFalse(attached.owns_engine)
+        attached.close()
+        self.assertTrue(attached.closed)
+        self.assertEqual(self.bridge.engine_instance_id, self.bridge.health()["engine_instance_id"])
 
     def test_automation_bridge_api_end_to_end(self):
         previous_port = None

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -168,6 +168,81 @@ def _count_light_pixels_in_rect(path, rect):
 
 
 class EngineClientUnitTest(unittest.TestCase):
+    def test_doctor_reports_invalid_project_without_launching(self):
+        with tempfile.TemporaryDirectory() as root, mock.patch.object(editor, "open_project") as open_project:
+            report = editor.doctor(root)
+        self.assertFalse(report.ready)
+        self.assertEqual("project", report.checks[0].name)
+        self.assertIn("game.project", report.checks[0].action)
+        json.dumps(report.as_dict())
+        open_project.assert_not_called()
+
+    def test_doctor_reports_connection_failure_without_launching_or_writing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "game.project").write_text("[project]\ntitle = Test\n")
+            before = sorted(root.rglob("*"))
+            with mock.patch.object(editor, "installations", return_value=[]), mock.patch.object(editor, "open_project") as launch:
+                report = editor.doctor(root)
+            self.assertEqual(before, sorted(root.rglob("*")))
+        self.assertFalse(report.ready)
+        checks = {check.name: check for check in report.checks}
+        self.assertEqual("error", checks["editor_connection"].status)
+        self.assertIn("sandbox", checks["editor_connection"].action)
+        launch.assert_not_called()
+
+    def test_doctor_validates_cached_engine_without_collectors_or_cache_writes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "game.project").write_text("[project]\ntitle = Test\n")
+            native = root / "automation_bridge"
+            native.mkdir()
+            (native / "ext.manifest").touch()
+            project = EditorApiClient(root, port=1234)
+            project._engine_service_port = 1235
+            project._cached_engine_identity = {"port": 1235, "engine_instance_id": "e1", "project_identity": "p1"}
+            health = {"version": "2", "identity": {"engine_instance_id": "e1", "project_identity": "p1"}, "capabilities": ["elements"]}
+            with mock.patch.object(editor, "installations", return_value=[]), \
+                 mock.patch.object(editor, "Client", return_value=project), \
+                 mock.patch.object(project, "_check_connection"), \
+                 mock.patch.object(project, "_write_cached_engine_identity") as write, \
+                 mock.patch.object(engine.RuntimeLogs, "start") as collect, \
+                 mock.patch.object(editor, "request_json", return_value=(200, {"lines": []})), \
+                 mock.patch.object(EngineClient, "_request", return_value=health):
+                report = editor.doctor(root, required_capabilities=("elements",))
+                missing = editor.doctor(root, required_capabilities=("unavailable",))
+        self.assertTrue(report.ready)
+        self.assertFalse(missing.ready)
+        self.assertIn("unavailable", missing.checks[-1].message)
+        write.assert_not_called()
+        collect.assert_not_called()
+
+    def test_install_python_uses_fetched_archive_without_editing_project(self):
+        dependency = "https://github.com/defold/extension-automation-bridge/archive/refs/tags/2.1.0.zip"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            content = f"[project]\ntitle = Existing\ndependencies#3 = {dependency}\n"
+            (root / "game.project").write_text(content)
+            self._write_automation_bridge_archive(root, dependency)
+            with mock.patch.object(editor, "open_project") as launch:
+                path = editor.install_python(root)
+            self.assertEqual("new", (path / "automation_bridge" / "__init__.py").read_text())
+            self.assertEqual(content, (root / "game.project").read_text())
+        launch.assert_not_called()
+
+    def test_install_python_rejects_ambiguous_dependencies_and_preserves_wrapper(self):
+        dependency = "https://github.com/defold/extension-automation-bridge/archive/refs/tags/2.1.0.zip"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "game.project").write_text(f"[project]\ndependencies#0 = {dependency}\ndependencies#1 = {dependency}\n")
+            wrapper = root / "automation-bridge-python"
+            wrapper.mkdir()
+            marker = wrapper / "existing.py"
+            marker.write_text("original")
+            with self.assertRaisesRegex(editor.AutomationBridgeUpdateError, "ambiguous"):
+                editor.install_python(root)
+            self.assertEqual("original", marker.read_text())
+
     def test_public_surface_excludes_removed_aliases_and_backend_types(self):
         bridge = EngineClient(1)
         removed_client_names = {

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -168,6 +168,22 @@ def _count_light_pixels_in_rect(path, rect):
 
 
 class EngineClientUnitTest(unittest.TestCase):
+    def test_required_runtime_does_not_silently_skip_missing_editor(self):
+        with mock.patch.dict(os.environ, {"AUTOMATION_BRIDGE_REQUIRE_RUNTIME": "1"}):
+            with self.assertRaisesRegex(RuntimeError, "missing editor"):
+                AutomationBridgeApiTest.runtime_unavailable("missing editor")
+        with mock.patch.dict(os.environ, {"AUTOMATION_BRIDGE_REQUIRE_RUNTIME": "0"}):
+            with self.assertRaises(unittest.SkipTest):
+                AutomationBridgeApiTest.runtime_unavailable("missing editor")
+
+    def test_runtime_teardown_only_terminates_owned_engine(self):
+        for owned in (True, False):
+            bridge = mock.Mock()
+            with self.subTest(owned=owned), mock.patch.object(AutomationBridgeApiTest, "bridge", bridge, create=True), mock.patch.object(AutomationBridgeApiTest, "_owns_runtime", owned, create=True):
+                AutomationBridgeApiTest.close_bridge()
+            self.assertEqual(int(owned), bridge.close_engine.call_count)
+            self.assertEqual(int(not owned), bridge.close.call_count)
+
     def test_application_catalog_retains_contracts_and_pagination(self):
         bridge = EngineClient(12345)
         bridge._last_health = {"capabilities": ["application.catalog"]}
@@ -259,6 +275,16 @@ class EngineClientUnitTest(unittest.TestCase):
                 bridge.input.wait(42)
         self.assertEqual(["/input/cancel"], [path for _, path, _ in bridge.api_requests])
         self.assertTrue(bridge.api_requests[0][2]["release"])
+
+    def test_cancelled_accepted_receipt_wait_honors_cleanup_option(self):
+        for cleanup in (True, False):
+            token = engine.CancellationToken()
+            bridge = FakeInputClient()
+            with self.subTest(cleanup=cleanup), self.assertRaises(engine.OperationCancelled):
+                with engine.cancellation_scope(token):
+                    token.cancel()
+                    bridge.input.wait({"input_id": 42, "state": "accepted"}, state="accepted", cancel_on_interrupt=cleanup)
+            self.assertEqual(["/input/cancel"] if cleanup else [], [path for _, path, _ in bridge.api_requests])
 
     def test_client_scope_releases_its_input_when_scene_wait_is_cancelled(self):
         bridge = FakeInputClient()
@@ -3512,9 +3538,16 @@ class AutomationBridgeApiTest(unittest.TestCase):
     SPRITE_COUNTER_NAME = "Sprite"
 
     @classmethod
+    def runtime_unavailable(cls, message):
+        if os.environ.get("AUTOMATION_BRIDGE_REQUIRE_RUNTIME") == "1":
+            raise RuntimeError(message)
+        raise unittest.SkipTest(message)
+
+    @classmethod
     def setUpClass(cls):
         cls.editor = None
         cls.bridge = None
+        cls._owns_runtime = False
         port = os.environ.get("AUTOMATION_BRIDGE_ENGINE_PORT")
         if port:
             remotery_url = os.environ.get("AUTOMATION_BRIDGE_REMOTERY_URL")
@@ -3526,12 +3559,12 @@ class AutomationBridgeApiTest(unittest.TestCase):
             return
 
         if not (ROOT / ".internal" / "editor.port").is_file():
-            raise unittest.SkipTest("Defold editor port file is missing")
+            cls.runtime_unavailable("Defold editor port file is missing")
 
         try:
             cls.editor = editor.open_project(ROOT, start_if_needed=False)
         except (FileNotFoundError, editor.NotRunningError) as exc:
-            raise unittest.SkipTest(str(exc)) from exc
+            cls.runtime_unavailable(str(exc))
 
     @classmethod
     def close_bridge(cls):
@@ -3539,7 +3572,10 @@ class AutomationBridgeApiTest(unittest.TestCase):
             return
         bridge = cls.bridge
         cls.bridge = None
-        bridge.close_engine()
+        if cls._owns_runtime:
+            bridge.close_engine()
+        else:
+            bridge.close()
 
     @classmethod
     def tearDownClass(cls):
@@ -3558,7 +3594,7 @@ class AutomationBridgeApiTest(unittest.TestCase):
         self.assertEqual(1, second.offset)
         self.assertNotEqual(first.elements[0].logical_id, second.elements[0].logical_id)
         self.assertGreaterEqual(second.engine_frame, first.engine_frame)
-        for params in ({"limit": "invalid"}, {"limit": 501}, {"cursor": "invalid"}, {"offset": -1}):
+        for params in ({"limit": "invalid"}, {"limit": 501}, {"cursor": "invalid"}, {"offset": -1}, {"offset": "9" * 30}, {"cursor": "9" * 30}):
             with self.subTest(params=params), self.assertRaises(AutomationBridgeApiError) as error:
                 self.bridge.request("GET", "/elements", params=params)
             self.assertEqual(400, error.exception.status)
@@ -3583,7 +3619,30 @@ class AutomationBridgeApiTest(unittest.TestCase):
                 self.bridge.request("GET", "/application/catalog", params=params)
             self.assertEqual(400, error.exception.status)
 
+    def test_application_contract_validation_and_replacement_are_atomic(self):
+        self.ensure_running_bridge()
+        checks = self.bridge.state("sample.contract_checks").value["rejected"]
+        self.assertEqual(13, len(checks))
+        self.assertTrue(all(checks), checks)
+        future = self.bridge.application_catalog(kind="state", name="sample.future")
+        self.assertEqual("Replacement declaration", future.entries[0].description)
+        self.assertIs(False, future.entries[0].schema)
+        self.assertEqual(0, len(self.bridge.states(name="sample.future")["states"]))
+        undocumented = self.bridge.application_catalog(kind="command", name="sample.catalog_probe")
+        self.assertEqual({}, undocumented.entries[0].contract)
+        self.assertEqual({"available": True}, self.bridge.command("sample.catalog_probe")["result"])
+        before = self.bridge.application_catalog().revision
+        result = self.bridge.command("sample.catalog_reject")
+        self.assertTrue(result["result"]["rejected"])
+        self.assertEqual(before, self.bridge.application_catalog().revision)
+
     def test_session_ownership_and_detach_leave_engine_available(self):
+        if self.editor is not None:
+            self.bridge = self.editor.build_and_run(timeout=20, client_id="owner", session_id="lifecycle-test")
+            self.__class__.bridge = self.bridge
+            self.__class__._owns_runtime = True
+            self.assertTrue(self.bridge.owns_engine)
+            self.assertEqual("lifecycle-test", self.bridge.session_info()["session_id"])
         self.ensure_running_bridge()
         attached = engine.connect(self.bridge.port, client_id="observer", session_id="detach-test")
         self.assertFalse(attached.owns_engine)
@@ -3607,6 +3666,46 @@ class AutomationBridgeApiTest(unittest.TestCase):
         self.assertLess(receipt["actual_duration"], 4)
         self.assertEqual("released", self.bridge.key("SPACE", wait="released").state)
 
+    def test_competing_clients_preserve_ownership_and_allow_observation(self):
+        self.ensure_running_bridge()
+        # Exercise both halves of the native identity pair.
+        for client_id, session_id in ((self.bridge.client_id, "competing-session"), ("competing-client", self.bridge.session_id)):
+            with self.subTest(client_id=client_id, session_id=session_id):
+                with engine.connect(self.bridge.port, client_id=client_id, session_id=session_id) as observer:
+                    held = self.bridge.key("SPACE", hold=5, wait="started")
+                    try:
+                        self.assertGreater(observer.elements_page(limit=0).matched, 0)
+                        for mutation in (lambda: observer.key("SPACE"), lambda: observer.input.cancel(held.input_id), lambda: observer.input.flush()):
+                            with self.assertRaises(AutomationBridgeApiError) as error:
+                                mutation()
+                            self.assertEqual("input_controller_busy", error.exception.code)
+                            self.assertEqual(409, error.exception.status)
+                        self.assertEqual("started", self.bridge.input.status(held.input_id).state)
+                    finally:
+                        self.bridge.input.flush()
+                    wait_until(lambda: self.bridge.input.status(held.input_id), predicate=lambda item: item.state == "cancelled", timeout=2)
+
+    def test_native_lease_expiry_allows_another_client_to_acquire_control(self):
+        self.ensure_running_bridge()
+        self.bridge.input.configure(lease=0.2)
+
+        def acquire(client):
+            try:
+                return client.input.configure(lease=0.3)
+            except AutomationBridgeApiError as exc:
+                if exc.code != "input_controller_busy":
+                    raise
+                return None
+
+        try:
+            with engine.connect(self.bridge.port, client_id="lease-successor", session_id="lease-test") as successor:
+                wait_until(lambda: acquire(successor), timeout=2, interval=0.01)
+                with self.assertRaises(AutomationBridgeApiError) as error:
+                    self.bridge.input.configure()
+                self.assertEqual("input_controller_busy", error.exception.code)
+        finally:
+            wait_until(lambda: acquire(self.bridge), timeout=2, interval=0.01)
+
     def test_automation_bridge_api_end_to_end(self):
         previous_port = None
         run_count = 1 if self.editor is None else 2
@@ -3615,6 +3714,7 @@ class AutomationBridgeApiTest(unittest.TestCase):
             if self.editor is not None:
                 self.bridge = self.editor.build_and_run(timeout=20)
                 self.__class__.bridge = self.bridge
+                self.__class__._owns_runtime = True
                 self.bridge.wait_ready()
                 if previous_port is not None:
                     self.assertNotEqual(previous_port, self.bridge.port)
@@ -3718,6 +3818,7 @@ class AutomationBridgeApiTest(unittest.TestCase):
         before = self.label_count("L1")
         self.bridge.click(spawner)
         wait_until(lambda: self.label_count("L1") > before, timeout=2, message="circular-drag item missing")
+        self.arrange_items()
         item_label = self.bridge.element(type="labelc", text="L1", visible=True)
         item = self.bridge.parent(item_label)
         center_x = float(item.center["x"])
@@ -3927,9 +4028,10 @@ class AutomationBridgeApiTest(unittest.TestCase):
             self.bridge.wait_ready()
             return
         if self.editor is None:
-            raise unittest.SkipTest("no Automation Bridge engine or Defold editor is available")
+            self.runtime_unavailable("no Automation Bridge engine or Defold editor is available")
         self.bridge = self.editor.build_and_run(timeout=20)
         self.__class__.bridge = self.bridge
+        self.__class__._owns_runtime = True
         self.bridge.wait_ready()
 
     def supports_capability(self, capability):
@@ -4327,6 +4429,8 @@ class AutomationBridgeApiTest(unittest.TestCase):
         return self.bridge.count(type="labelc", text=label)
 
     def parents_for_label(self, label):
+        self.arrange_items()
+
         def resolve_parents():
             parents = []
             elements = self.bridge.elements(type="labelc", text=label, limit=100)
@@ -4345,6 +4449,12 @@ class AutomationBridgeApiTest(unittest.TestCase):
             message=f"missing pair for {label}: {self.item_labels()}",
         )
         return parents
+
+    def arrange_items(self):
+        result = self.bridge.command("sample.arrange_items")
+        self.assertEqual("completed", result["state"], result)
+        self.bridge.wait_frames(1)
+        self.assertEqual(len(self.item_labels()), result["result"]["arranged"])
 
 
 class _ClientCloseFailure:

--- a/tests/test_tooling.py
+++ b/tests/test_tooling.py
@@ -348,8 +348,10 @@ class MetalCaptureTest(unittest.TestCase):
         ]
         bridge = self.Bridge(states)
         with tempfile.TemporaryDirectory() as directory:
+            output_path = Path(directory) / "traces" / "frame.gputrace"
+            expected_path = output_path.resolve()
             capture = MetalCaptureClient(bridge).start(
-                Path(directory) / "traces" / "frame.gputrace",
+                output_path,
                 frames=2,
                 timeout=1,
             )
@@ -358,7 +360,7 @@ class MetalCaptureTest(unittest.TestCase):
         self.assertEqual(2, capture.frames_captured)
         self.assertEqual(("POST", "/metal"), bridge.requests[0][:2])
         self.assertIsNone(bridge.requests[0][2])
-        self.assertTrue(bridge.requests[0][3]["path"].endswith("/traces/frame.gputrace"))
+        self.assertEqual(expected_path, Path(bridge.requests[0][3]["path"]))
         self.assertEqual(2, bridge.requests[0][3]["frames"])
         self.assertEqual(
             ["metal_capture_started", "metal_capture_finished"],


### PR DESCRIPTION
Automation scripts can now diagnose setup problems, install the matching Python wrapper, discover game commands and data contracts, and cancel ongoing waits. Editor discovery handles slow responses without launching duplicate editors, and clients can detach while leaving the game running.

### Technical changes

- Retry editor discovery within the timeout, reread the port file, and preserve connection errors.
- Add `editor.doctor()`, `editor.install_python()`, and a standalone installer using fetched dependency archives.
- Add typed element selectors and paginated results with counts, cursors, and snapshot metadata. Reject malformed pagination and ambiguous single-element queries.
- Forward client/session identities through editor workflows and expose lifecycle ownership, session information, and idempotent client cleanup.
- Add cooperative cancellation across waits, input, commands, logs, and captures, with native cleanup requests and preserved cleanup errors.
- Add Lua `automation_bridge.describe()`, the `application.catalog` capability and endpoint, and typed Python catalog results. Schemas document application contracts without enforcing payload validation.
- Add Python 3.10/3.14 CI on Linux, macOS, and Windows, plus deterministic fixtures and native integration coverage.
- Validation: all 207 tests passed, including native integration checks.