### PR TITLE
Support Defold 1.13.2 editor automation

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -25,4 +25,5 @@ jobs:
           python -m unittest
           tests.test_automation_bridge_api.EngineClientUnitTest
           tests.test_automation_bridge_api.EditorDiscoveryUnitTest
+          tests.test_automation_bridge_api.EditorCompatibilityUnitTest
           tests.test_tooling

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -70,7 +70,7 @@ with Python 3.10 and 3.14, independently of the native Bob build. For a local ru
 that never contacts an editor:
 
 ```sh
-PYTHONPATH=automation_bridge/automation-bridge-python python3 -m unittest tests.test_automation_bridge_api.EngineClientUnitTest tests.test_automation_bridge_api.EditorDiscoveryUnitTest tests.test_tooling
+PYTHONPATH=automation_bridge/automation-bridge-python python3 -m unittest tests.test_automation_bridge_api.EngineClientUnitTest tests.test_automation_bridge_api.EditorDiscoveryUnitTest tests.test_automation_bridge_api.EditorCompatibilityUnitTest tests.test_tooling
 ```
 
 Before merging changes to the shared protocol, open this sample project in
@@ -86,6 +86,12 @@ process is borrowed and remains running after teardown. Editor-specific tests
 still need the editor workflow. The ordinary command skips runtime tests when
 Defold is absent; `AUTOMATION_BRIDGE_REQUIRE_RUNTIME=1` turns unavailable runtime
 setup into a failure. It never launches the editor implicitly.
+
+Editor compatibility tests serve the versioned fixtures in `tests/fixtures`
+through local HTTP servers. They cover 1.13.1 command enums and acknowledgements,
+1.13.2 command paths and focus, compile/run, structured completion and errors,
+Bob authentication, and target URLs with console fallback. Feature availability
+comes from advertised capabilities, including when an early alpha lacks an API.
 
 Runtime checks cover pagination metadata and malformed values, built/borrowed
 clients, cancellation release, competing client/session identities, native lease

--- a/automation_bridge/automation-bridge-python/README.md
+++ b/automation_bridge/automation-bridge-python/README.md
@@ -345,6 +345,15 @@ zero-based source ranges, completion status, and an optional `target_url`.
 keep their return values. On 1.13.1, HTML5, hot reload, and debugger acknowledgements
 have `completed=False` and `success=None`; 1.13.2 reports their build completion.
 
+Use `project.compile()` on Defold 1.13.2 to validate resources and Lua without
+launching or bundling. It returns a `BuildResult`; compilation failures raise
+`BuildError`. When runtime testing is needed, call `project.build_and_run()`
+directly: it compiles and launches through `run` on 1.13.2 or `build` on 1.13.1.
+The default avoids taking focus where supported and preserves the legacy launch
+on 1.13.1. Explicit `focus=False` requires advertised focus control (1.13.2);
+`focus=True` works on either version. Unsupported requests fail before engine
+cleanup. `clean_build_and_run()` still uses the native focused launch on both.
+
 Declare mandatory capabilities during bootstrap or later with `require()`:
 
 ```python

--- a/automation_bridge/automation-bridge-python/README.md
+++ b/automation_bridge/automation-bridge-python/README.md
@@ -369,6 +369,14 @@ and output. The wrapper reads `.internal/editor.token` for each call and sends
 it as a bearer token. Missing or rejected credentials raise `CommandError`.
 Bob requests are never automatically retried after an uncertain transport failure.
 
+When a 1.13.2 build result includes a target URL, bootstrap connects to that
+target and validates native health, capabilities, and identity before caching it.
+The current engine transport supports `http://127.0.0.1:PORT` and
+`http://localhost:PORT`. Other targets raise `UnsupportedOperationError`; select
+a local engine in Defold. A reported target never falls back to historical ports
+or triggers an automatic rebuild. Results without a URL continue to use console
+registration and existing recovery behavior, including on Defold 1.13.1.
+
 Declare mandatory capabilities during bootstrap or later with `require()`:
 
 ```python

--- a/automation_bridge/automation-bridge-python/README.md
+++ b/automation_bridge/automation-bridge-python/README.md
@@ -331,6 +331,13 @@ for preference in project.preferences.list(prefix="code"):
 
 ## Capabilities
 
+Editor command discovery supports Defold 1.13.1's command enum and 1.13.2's
+individual OpenAPI paths. Use `project.commands.catalog()` for descriptions and
+parameter schemas, and `project.commands.supports("run", parameter="focus")`
+to probe support. Pass `refresh=True` to `catalog()` after capabilities change.
+New-feature `editor.UnsupportedOperationError` messages identify Defold 1.13.2
+as the minimum version; their `minimum_version` attribute is available to hosts.
+
 Declare mandatory capabilities during bootstrap or later with `require()`:
 
 ```python

--- a/automation_bridge/automation-bridge-python/README.md
+++ b/automation_bridge/automation-bridge-python/README.md
@@ -354,6 +354,21 @@ on 1.13.1. Explicit `focus=False` requires advertised focus control (1.13.2);
 `focus=True` works on either version. Unsupported requests fail before engine
 cleanup. `clean_build_and_run()` still uses the native focused launch on both.
 
+Defold 1.13.2 also supports Bob builds and bundles without launching:
+
+```python
+result = project.bob(
+    options={"platform": "wasm-web", "archive": True},
+    commands=("build", "bundle"),
+)
+```
+
+Bob option keys omit `--`; arrays supply repeatable options. Use
+`project.bob(options={"help": True})` and `project.console.read()` for Bob help
+and output. The wrapper reads `.internal/editor.token` for each call and sends
+it as a bearer token. Missing or rejected credentials raise `CommandError`.
+Bob requests are never automatically retried after an uncertain transport failure.
+
 Declare mandatory capabilities during bootstrap or later with `require()`:
 
 ```python

--- a/automation_bridge/automation-bridge-python/README.md
+++ b/automation_bridge/automation-bridge-python/README.md
@@ -338,6 +338,13 @@ to probe support. Pass `refresh=True` to `catalog()` after capabilities change.
 New-feature `editor.UnsupportedOperationError` messages identify Defold 1.13.2
 as the minimum version; their `minimum_version` attribute is available to hosts.
 
+`project.last_command_result` retains typed `editor.BuildResult` diagnostics after
+build/run, HTML5, hot reload, and debugger operations. It includes warnings,
+zero-based source ranges, completion status, and an optional `target_url`.
+`editor.BuildError.result` retains the same evidence on failure. Existing helpers
+keep their return values. On 1.13.1, HTML5, hot reload, and debugger acknowledgements
+have `completed=False` and `success=None`; 1.13.2 reports their build completion.
+
 Declare mandatory capabilities during bootstrap or later with `require()`:
 
 ```python

--- a/automation_bridge/automation-bridge-python/automation_bridge/client.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/client.py
@@ -884,6 +884,7 @@ class Client:
             *,
             registration_is_authoritative: bool,
             require_cached_identity_match: bool = False,
+            require_target_identity: bool = False,
         ) -> Optional["Client"]:
             try:
                 bridge = cls(
@@ -893,11 +894,20 @@ class Client:
                     **session_identity,
                 )
                 health = bridge.health()
+                if require_target_identity:
+                    identity = health.get("identity", {})
+                    if not isinstance(identity, Mapping) or any(
+                        not isinstance(identity.get(key), str) or not identity[key]
+                        for key in ("engine_instance_id", "project_identity")
+                    ):
+                        raise AutomationBridgeError("reported build target did not provide an engine and project identity")
                 if not editor._validate_cached_engine_health(
                     service_port,
                     health,
                     fresh_build=fresh_build or registration_is_authoritative,
                 ):
+                    if require_target_identity:
+                        raise AutomationBridgeError("reported build target identity does not match the cached project")
                     return None
                 if require_cached_identity_match and not editor._cached_engine_health_matches(
                     service_port,
@@ -907,6 +917,8 @@ class Client:
             except (IncompatibleApiVersionError, UnsupportedCapabilityError):
                 raise
             except AutomationBridgeError:
+                if require_target_identity:
+                    raise
                 return None
             identity = health.get("identity", {}) if isinstance(health, Mapping) else {}
             editor._remember_engine_service_port(
@@ -939,6 +951,25 @@ class Client:
                     return cached_bridge
 
         def bridge_after_build() -> Optional["Client"]:
+            target_port = editor._last_build_target_port if fresh_build else None
+            if target_port is not None:
+                bridge = connect_candidate(
+                    target_port, None,
+                    registration_is_authoritative=True,
+                    require_target_identity=True,
+                )
+                if bridge is not None:
+                    # The engine URL is authoritative; console metadata is optional.
+                    try:
+                        console_lines = editor._console_lines()
+                        if target_port in editor._current_registration_engine_service_ports(console_lines):
+                            profiler_url = cls._editor_profiler_url(editor, fresh_build=True, console_lines=console_lines)
+                            if profiler_url:
+                                bridge._remotery_url = profiler_url
+                                editor._remember_remotery_url(profiler_url)
+                    except AutomationBridgeError:
+                        pass
+                return bridge
             console_lines = editor._console_lines()
             service_ports = editor._engine_service_ports(console_lines)
             registration_ports = editor._current_registration_engine_service_ports(console_lines)
@@ -956,6 +987,15 @@ class Client:
                 if bridge is not None:
                     return bridge
             return None
+
+        if fresh_build and editor._last_build_target_port is not None:
+            # Do not try historical ports or relaunch after an explicit target.
+            return cls._wait_for_bridge(
+                bridge_after_build,
+                timeout=timeout,
+                message="Automation Bridge did not become healthy at the editor's reported target",
+                retry_exceptions=(AutomationBridgeError,),
+            )
 
         if fresh_build and cls._last_build_missing_engine_service_port(editor):
             return cls._recover_after_stale_build(editor, bridge_after_build, timeout, build_command, focus=focus)

--- a/automation_bridge/automation-bridge-python/automation_bridge/client.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/client.py
@@ -864,6 +864,7 @@ class Client:
         required_capabilities: Sequence[str] = (),
         client_id: Optional[str] = None,
         session_id: Optional[str] = None,
+        focus: Optional[bool] = None,
     ) -> "Client":
         """Private editor-owned bootstrap hook for engine discovery."""
         check_cancelled()
@@ -875,7 +876,7 @@ class Client:
         if fresh_build:
             cls._close_candidate_engine_ports(editor)
             cancellable_sleep(0.5)
-            editor._build_and_run_command(build_command, timeout=timeout)
+            editor._build_and_run_command(build_command, timeout=timeout, **({"focus": focus} if focus is not None else {}))
 
         def connect_candidate(
             service_port: int,
@@ -957,7 +958,7 @@ class Client:
             return None
 
         if fresh_build and cls._last_build_missing_engine_service_port(editor):
-            return cls._recover_after_stale_build(editor, bridge_after_build, timeout, build_command)
+            return cls._recover_after_stale_build(editor, bridge_after_build, timeout, build_command, focus=focus)
 
         try:
             return cls._wait_for_bridge(
@@ -970,7 +971,7 @@ class Client:
             if not fresh_build:
                 raise
 
-        return cls._recover_after_stale_build(editor, bridge_after_build, timeout, build_command)
+        return cls._recover_after_stale_build(editor, bridge_after_build, timeout, build_command, focus=focus)
 
     @classmethod
     def _recover_after_stale_build(
@@ -979,12 +980,14 @@ class Client:
         bridge_after_build: Any,
         timeout: float,
         build_command: Optional[str],
+        *,
+        focus: Optional[bool] = None,
     ) -> "Client":
         if build_command is None:
             raise RuntimeError("stale-build recovery requires a build command")
         cls._close_candidate_engine_ports(editor)
         cancellable_sleep(0.5)
-        editor._build_and_run_command(build_command, timeout=timeout)
+        editor._build_and_run_command(build_command, timeout=timeout, **({"focus": focus} if focus is not None else {}))
         return cls._wait_for_bridge(
             bridge_after_build,
             timeout=timeout,

--- a/automation_bridge/automation-bridge-python/automation_bridge/editor.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/editor.py
@@ -712,6 +712,7 @@ class Client:
         self._cached_engine_identity = self._read_cached_engine_identity()
         self._remotery_url: Optional[str] = self._read_cached_remotery_url()
         self._last_build_had_engine_service_port: Optional[bool] = None
+        self._last_build_target_port: Optional[int] = None
         self._last_command_result: Optional[BuildResult] = None
         self._lifecycle_events = []
         self._openapi_document: Optional[dict] = None
@@ -1324,6 +1325,8 @@ class Client:
         if command not in {"build", "run", "clean-build"}:
             raise ValueError(f"unsupported desktop build-and-run command: {command}")
         self._require_command(command)
+        self._last_build_target_port = None
+        self._last_build_had_engine_service_port = None
         url = f"{self.base_url}/command/{command}"
         if command == "run" or focus is not None:
             negotiated_focus = self._run_focus(command, focus)
@@ -1345,6 +1348,12 @@ class Client:
             raise
         self._record_lifecycle("editor_build_completed")
 
+        if result.target_url is not None:
+            self._last_build_target_port = self._local_target_port(result.target_url)
+            self._last_build_had_engine_service_port = True
+            self._record_lifecycle("editor_target_reported", port=self._last_build_target_port)
+            return result
+
         try:
             wait_until(
                 lambda: self._has_fresh_endpoint_registration(
@@ -1362,6 +1371,28 @@ class Client:
         self._last_build_had_engine_service_port = self._latest_registration_has_engine_service_port()
         cancellable_sleep(0.2)
         return result
+
+    @staticmethod
+    def _local_target_port(url: str) -> int:
+        """Accept only URLs representable by the IPv4 loopback engine client."""
+        try:
+            parsed = urllib.parse.urlsplit(url)
+            port = parsed.port
+            if (
+                parsed.scheme == "http" and parsed.hostname in {"127.0.0.1", "localhost"}
+                and port is not None and 1 <= port <= 65535
+                and parsed.username is None and parsed.password is None
+                and parsed.path in ("", "/") and not parsed.query and not parsed.fragment
+                and not any(char.isspace() for char in url)
+            ):
+                return port
+        except ValueError:
+            pass
+        raise UnsupportedOperationError(
+            "editor returned a target URL unsupported by the local engine client; "
+            "expected http://127.0.0.1:PORT or http://localhost:PORT. "
+            "Select a local engine target in Defold"
+        )
 
     def _console_lines(self) -> list:
         """Return current editor console lines."""

--- a/automation_bridge/automation-bridge-python/automation_bridge/editor.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/editor.py
@@ -1131,6 +1131,31 @@ class Client:
         self._last_command_result = None
         return request_json(f"{self.base_url}/command/{command}", method="POST", timeout=timeout)
 
+    def compile(self, *, timeout: float = 60.0) -> BuildResult:
+        """Compile project resources and Lua without launching or bundling.
+
+        Supported from Defold 1.13.2. Older editors raise
+        UnsupportedOperationError; this never falls back to a launching command.
+        Return completion and diagnostics, or raise BuildError with the result.
+        Use build_and_run() directly when a runtime is needed; it compiles too.
+        """
+        status, response = self._json_command("compile", timeout)
+        return self._accept_build_result("compile", f"{self.base_url}/command/compile", status, response)
+
+    def _run_focus(self, command: str, focus: Optional[bool]) -> Optional[bool]:
+        if focus is not None and type(focus) is not bool:
+            raise ValueError("focus must be a boolean or None")
+        self._require_command(command)
+        if self.commands.supports(command, parameter="focus"):
+            return False if focus is None else focus
+        if focus is False:
+            raise UnsupportedOperationError(
+                f"editor does not advertise focus control for {command!r}",
+                minimum_version="1.13.2",
+            )
+        # Legacy commands launch with focus. Do not send parameters they ignore.
+        return None
+
     def connect_engine(
         self,
         *,
@@ -1161,11 +1186,19 @@ class Client:
         self,
         *,
         timeout: float = 60.0,
+        focus: Optional[bool] = None,
         required_capabilities: Sequence[str] = (),
         client_id: Optional[str] = None,
         session_id: Optional[str] = None,
     ) -> EngineClient:
-        """Build a new engine and return a client with owns_engine=True.
+        """Compile, launch, and return a client with owns_engine=True.
+
+        Uses ``run`` on Defold 1.13.2 and ``build`` on 1.13.1. Omitted focus
+        defaults to False when the editor advertises focus control, otherwise
+        preserves the legacy focused launch. Explicit ``focus=False`` requires
+        Defold 1.13.2. ``focus=True`` requests the native focused launch on both.
+        Unsupported requests fail before closing any engine. Build evidence is
+        available in ``last_command_result``; no separate compile is needed.
 
         Explicit client/session IDs let one logical automation session reconnect.
         Use distinct IDs for independent agents; the native input lease remains
@@ -1173,13 +1206,18 @@ class Client:
         """
         from .client import Client as EngineClient
 
+        if focus is not None and type(focus) is not bool:
+            raise ValueError("focus must be a boolean or None")
+        command = "run" if self.commands.supports("run") else "build"
+        negotiated_focus = self._run_focus(command, focus)
         return EngineClient._from_editor(
             self,
-            build_command="build",
+            build_command=command,
             timeout=timeout,
             required_capabilities=required_capabilities,
             client_id=client_id,
             session_id=session_id,
+            **({"focus": negotiated_focus} if negotiated_focus is not None else {}),
         )
 
 
@@ -1191,7 +1229,10 @@ class Client:
         client_id: Optional[str] = None,
         session_id: Optional[str] = None,
     ) -> EngineClient:
-        """Build a new engine and return a client with owns_engine=True.
+        """Clear build caches, rebuild, launch, and return an owned engine client.
+
+        Use only to recover from stale build caches. The native clean-build
+        command launches with focus on both Defold 1.13.1 and 1.13.2.
 
         Explicit client/session IDs let one logical automation session reconnect.
         Use distinct IDs for independent agents; the native input lease remains
@@ -1199,6 +1240,7 @@ class Client:
         """
         from .client import Client as EngineClient
 
+        self._require_command("clean-build")
         return EngineClient._from_editor(
             self,
             build_command="clean-build",
@@ -1217,12 +1259,17 @@ class Client:
         """
         self._empty_command("build-html5", timeout)
 
-    def _build_and_run_command(self, command: str, timeout: float = 60.0) -> BuildResult:
+    def _build_and_run_command(self, command: str, timeout: float = 60.0, *, focus: Optional[bool] = None) -> BuildResult:
         """Execute a desktop build-and-run command and await endpoint registration."""
         check_cancelled()
-        if command not in {"build", "clean-build"}:
+        if command not in {"build", "run", "clean-build"}:
             raise ValueError(f"unsupported desktop build-and-run command: {command}")
         self._require_command(command)
+        url = f"{self.base_url}/command/{command}"
+        if command == "run" or focus is not None:
+            negotiated_focus = self._run_focus(command, focus)
+            if negotiated_focus is not None:
+                url += "?" + urllib.parse.urlencode({"focus": "true" if negotiated_focus else "false"})
         self._record_lifecycle("editor_build_started")
         previous_lines = self._console_lines()
         previous_registration_count = self._endpoint_registered_count(previous_lines)
@@ -1231,7 +1278,6 @@ class Client:
         if previous_port is not None:
             self._engine_service_port = previous_port
         self._last_command_result = None
-        url = f"{self.base_url}/command/{command}"
         try:
             status, response = request_json(url, method="POST", timeout=timeout)
             result = self._accept_build_result(command, url, status, response)

--- a/automation_bridge/automation-bridge-python/automation_bridge/editor.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/editor.py
@@ -52,6 +52,7 @@ _SUPPORTED_COMMANDS = frozenset({
 })
 _SUPPORTED_PATHS = frozenset({
     ("/command/{command}", "post"),
+    ("/bob", "post"),
     ("/console", "get"),
     ("/console/stream", "get"),
     ("/prefs/{path}", "get"),
@@ -1044,7 +1045,10 @@ class Client:
             raise UnsupportedOperationError(f"editor operation is outside the supported API: {method.upper()} {path}")
         operation = self._openapi().get("paths", {}).get(path, {}).get(method.lower())
         if not isinstance(operation, Mapping):
-            raise UnsupportedOperationError(f"editor does not advertise {method.upper()} {path}")
+            raise UnsupportedOperationError(
+                f"editor does not advertise {method.upper()} {path}",
+                minimum_version="1.13.2" if path == "/bob" else None,
+            )
         return operation
 
     def _command_info(self, command: str) -> Optional[CommandInfo]:
@@ -1141,6 +1145,61 @@ class Client:
         """
         status, response = self._json_command("compile", timeout)
         return self._accept_build_result("compile", f"{self.base_url}/command/compile", status, response)
+
+    def bob(
+        self,
+        *,
+        options: Optional[Mapping[str, Any]] = None,
+        commands: Sequence[str] = (),
+        timeout: float = 300.0,
+    ) -> BuildResult:
+        """Build or bundle through the editor's Bob endpoint without launching.
+
+        Supported from Defold 1.13.2. ``options`` uses Bob CLI keys without
+        ``--``; repeatable values are arrays. For example, pass
+        ``options={"platform": "wasm-web", "archive": True}`` and
+        ``commands=("build", "bundle")`` to bundle HTML5. ``options={"help": True}``
+        prints available options to the editor console. Bob decides output paths
+        and defaults. Output is available through ``project.console.read()``.
+
+        Authentication reads ``.internal/editor.token`` on every call. Missing
+        or rejected credentials raise CommandError. Requests are not retried:
+        after a timeout, inspect the console before repeating a build. Return
+        completion and diagnostics, or raise BuildError with the result.
+        """
+        if options is not None and (not isinstance(options, Mapping) or any(not isinstance(key, str) for key in options)):
+            raise ValueError("Bob options must be an object with string keys")
+        if not isinstance(commands, Sequence) or isinstance(commands, (str, bytes)) or any(not isinstance(command, str) for command in commands):
+            raise ValueError("Bob commands must be a sequence of strings")
+        body = {"options": dict(options) if options is not None else {}, "commands": list(commands)}
+        # Validate before authentication or execution, including non-finite values.
+        try:
+            data = json.dumps(body, ensure_ascii=False, allow_nan=False).encode("utf-8")
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Bob options must contain valid JSON values") from exc
+        check_cancelled()
+        self._require_operation("/bob", "post")
+        token_path = self.root / ".internal" / "editor.token"
+        try:
+            token = token_path.read_text(encoding="utf-8").strip()
+        except (OSError, UnicodeError):
+            raise CommandError(f"cannot read editor authentication token at {token_path}; reopen the project in Defold 1.13.2 or later") from None
+        if not token or any(char.isspace() or not 33 <= ord(char) <= 126 for char in token):
+            raise CommandError(f"invalid editor authentication token at {token_path}; reopen the project")
+        self._last_command_result = None
+        url = f"{self.base_url}/bob"
+        try:
+            status, response = request_json(
+                url, method="POST", timeout=timeout, data=data,
+                headers={"Content-Type": "application/json", "Authorization": f"Bearer {token}"},
+            )
+        except HttpError as exc:
+            if exc.status not in (401, 403):
+                raise
+            raise CommandError("Bob authentication was rejected; reconnect to the editor and check .internal/editor.token") from None
+        if status in (401, 403):
+            raise CommandError("Bob authentication was rejected; reconnect to the editor and check .internal/editor.token")
+        return self._accept_build_result("bob", url, status, response)
 
     def _run_focus(self, command: str, focus: Optional[bool]) -> Optional[bool]:
         if focus is not None and type(focus) is not bool:

--- a/automation_bridge/automation-bridge-python/automation_bridge/editor.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/editor.py
@@ -45,7 +45,7 @@ _ENGINE_SERVICE_PORT_PATTERNS = (
 )
 _REMOTERY_URL_PATTERN = re.compile(r"Initialized Remotery \((ws://[^)\s]+)\)")
 _SUPPORTED_COMMANDS = frozenset({
-    "build", "clean-build", "build-html5", "fetch-libraries", "hot-reload",
+    "build", "run", "compile", "clean-build", "build-html5", "fetch-libraries", "hot-reload",
     "rebundle", "reload-extensions", "reload-stylesheets", "debugger-start",
     "debugger-stop", "debugger-break", "debugger-continue", "debugger-detach",
     "debugger-step-into", "debugger-step-out", "debugger-step-over",
@@ -66,6 +66,7 @@ _EXCLUDED_COMMANDS = frozenset({
     "show-curve-editor", "toggle-pane-bottom", "toggle-pane-left", "toggle-pane-right",
 })
 _EXCLUDED_PATHS = frozenset({("/eval", "post")})
+_COMMAND_MINIMUM_VERSIONS = {"compile": "1.13.2", "run": "1.13.2"}
 
 
 Error = AutomationBridgeError
@@ -81,6 +82,12 @@ class LaunchError(Error):
 
 class UnsupportedOperationError(Error):
     """Raised when the connected editor does not advertise an operation."""
+
+    def __init__(self, message: str, *, minimum_version: Optional[str] = None):
+        self.minimum_version = minimum_version
+        if minimum_version is not None:
+            message += f"; supported from Defold {minimum_version}. Upgrade the connected editor to use this feature"
+        super().__init__(message)
 
 
 class CommandError(Error):
@@ -472,9 +479,43 @@ class Installation:
     last_launched_at: str
 
 
+@dataclass(frozen=True)
+class CommandInfo:
+    """An advertised editor command supported by this wrapper.
+
+    ``parameters`` retains OpenAPI parameter descriptions and schemas. Legacy
+    command-enum metadata is normalized to a concrete ``path``; UI-only commands
+    outside this wrapper's supported surface are excluded from discovery.
+    """
+
+    name: str
+    path: str
+    summary: str
+    description: str
+    parameters: tuple[Mapping[str, Any], ...]
+    raw: Mapping[str, Any]
+
+
 class Commands:
     def __init__(self, client: "Client"):
         self._client = client
+
+    def catalog(self, *, refresh: bool = False) -> tuple[CommandInfo, ...]:
+        """List supported commands from either editor OpenAPI format.
+
+        The first call reads OpenAPI; later calls reuse it. Pass ``refresh=True``
+        after editor capabilities change. Discovery does not execute commands.
+        """
+        if refresh:
+            self._client._check_connection(timeout=10.0)
+        return tuple(info for name in sorted(_SUPPORTED_COMMANDS) if (info := self._client._command_info(name)) is not None)
+
+    def supports(self, command: str, *, parameter: Optional[str] = None) -> bool:
+        """Check advertisement of a supported command or one of its query parameters."""
+        info = self._client._command_info(command)
+        return info is not None and (parameter is None or any(
+            item.get("name") == parameter and item.get("in") == "query" for item in info.parameters
+        ))
 
     def fetch_libraries(self, timeout: float = 60.0) -> FetchLibrariesResult:
         status, response = self._client._json_command("fetch-libraries", timeout)
@@ -956,16 +997,42 @@ class Client:
             raise UnsupportedOperationError(f"editor does not advertise {method.upper()} {path}")
         return operation
 
-    def _require_command(self, command: str) -> None:
-        operation = self._require_operation("/command/{command}", "post")
-        names = set()
-        for parameter in operation.get("parameters", ()):
-            if isinstance(parameter, Mapping) and parameter.get("name") == "command":
-                schema = parameter.get("schema", {})
-                if isinstance(schema, Mapping):
-                    names.update(str(value) for value in schema.get("enum", ()))
-        if command not in names:
-            raise UnsupportedOperationError(f"editor does not advertise command {command!r}")
+    def _command_info(self, command: str) -> Optional[CommandInfo]:
+        if not isinstance(command, str) or command not in _SUPPORTED_COMMANDS:
+            return None
+        paths = self._openapi().get("paths", {})
+        path = f"/command/{command}"
+        path_item = paths.get(path, {})
+        operation = path_item.get("post") if isinstance(path_item, Mapping) else None
+        if not isinstance(operation, Mapping):
+            path_item = paths.get("/command/{command}", {})
+            operation = path_item.get("post") if isinstance(path_item, Mapping) else None
+            if not isinstance(operation, Mapping):
+                return None
+            advertised = any(
+                isinstance(item, Mapping) and item.get("name") == "command"
+                and isinstance(item.get("schema"), Mapping)
+                and command in item["schema"].get("enum", ())
+                for item in (*path_item.get("parameters", ()), *operation.get("parameters", ()))
+            )
+            if not advertised:
+                return None
+        # Operation-level declarations override parameters shared by a path.
+        parameters = {
+            (item.get("name"), item.get("in")): dict(item)
+            for item in (*path_item.get("parameters", ()), *operation.get("parameters", ()))
+            if isinstance(item, Mapping) and isinstance(item.get("name"), str) and item.get("name") != "command"
+        }
+        return CommandInfo(command, path, str(operation.get("summary", "")), str(operation.get("description", "")), tuple(parameters.values()), dict(operation))
+
+    def _require_command(self, command: str) -> CommandInfo:
+        info = self._command_info(command)
+        if info is None:
+            raise UnsupportedOperationError(
+                f"editor does not advertise supported command {command!r}",
+                minimum_version=_COMMAND_MINIMUM_VERSIONS.get(command),
+            )
+        return info
 
     def _empty_command(self, command: str, timeout: float) -> None:
         check_cancelled()
@@ -1517,6 +1584,7 @@ __all__ = [
     "BuildIssue",
     "Client",
     "CommandError",
+    "CommandInfo",
     "Commands",
     "Console",
     "ConsoleRegion",

--- a/automation_bridge/automation-bridge-python/automation_bridge/editor.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/editor.py
@@ -99,10 +99,11 @@ class AutomationBridgeUpdateError(Error):
 
 
 class BuildError(CommandError):
-    """Raised when a build-and-run command reports compilation issues."""
+    """A build operation failed; ``issues`` and ``result`` retain diagnostics."""
 
-    def __init__(self, issues: Sequence["BuildIssue"]):
+    def __init__(self, issues: Sequence["BuildIssue"], *, result: Optional["BuildResult"] = None):
         self.issues = tuple(issues)
+        self.result = result
         super().__init__(f"Defold build failed: {list(self.issues)!r}")
 
 
@@ -365,6 +366,8 @@ class SourceRange:
 
 @dataclass(frozen=True)
 class BuildIssue:
+    """An editor diagnostic; source positions use zero-based LSP coordinates."""
+
     severity: str
     message: str
     resource: Optional[str] = None
@@ -372,22 +375,51 @@ class BuildIssue:
 
     @classmethod
     def from_raw(cls, raw: Mapping[str, Any]) -> "BuildIssue":
+        for name in ("severity", "message"):
+            if not isinstance(raw.get(name), str):
+                raise ValueError(f"build issue {name} must be a string")
+        if "resource" in raw and not isinstance(raw["resource"], str):
+            raise ValueError("build issue resource must be a string")
         raw_range = raw.get("range")
         source_range = None
-        if isinstance(raw_range, Mapping):
-            start = raw_range.get("start")
-            end = raw_range.get("end")
-            if isinstance(start, Mapping) and isinstance(end, Mapping):
-                source_range = SourceRange(
-                    SourcePosition(int(start.get("line", 0)), int(start.get("character", 0))),
-                    SourcePosition(int(end.get("line", 0)), int(end.get("character", 0))),
-                )
+        if "range" in raw:
+            if not isinstance(raw_range, Mapping):
+                raise ValueError("build issue range must be an object")
+            positions = []
+            for name in ("start", "end"):
+                position = raw_range.get(name)
+                if not isinstance(position, Mapping) or any(
+                    type(position.get(key)) is not int or position[key] < 0
+                    for key in ("line", "character")
+                ):
+                    raise ValueError(f"build issue range.{name} requires non-negative integer line and character")
+                positions.append(SourcePosition(position["line"], position["character"]))
+            source_range = SourceRange(*positions)
         return cls(
-            severity=str(raw.get("severity", "error")),
-            message=str(raw.get("message", "")),
-            resource=str(raw["resource"]) if raw.get("resource") is not None else None,
+            severity=raw["severity"],
+            message=raw["message"],
+            resource=raw.get("resource"),
             range=source_range,
         )
+
+
+@dataclass(frozen=True)
+class BuildResult:
+    """Editor completion evidence for a build or command.
+
+    ``completed`` is true only when the editor returned a structured build
+    result. Legacy text/empty acknowledgements have ``completed=False`` and
+    ``success=None``. Warnings may accompany success. ``target_url`` is optional
+    even after a successful launch. ``raw`` preserves additional response fields.
+    """
+
+    command: str
+    status: int
+    completed: bool
+    success: Optional[bool]
+    issues: tuple[BuildIssue, ...]
+    target_url: Optional[str]
+    raw: Mapping[str, Any]
 
 
 @dataclass(frozen=True)
@@ -534,6 +566,11 @@ class Commands:
         return result
 
     def hot_reload(self, timeout: float = 60.0) -> None:
+        """Hot reload; inspect ``project.last_command_result`` for completion.
+
+        Defold 1.13.2 waits and reports build issues. Defold 1.13.1 only
+        acknowledges the request; acknowledgement does not establish completion.
+        """
         self._client._empty_command("hot-reload", timeout)
 
     def rebundle(self, timeout: float = 60.0) -> None:
@@ -554,6 +591,7 @@ class Debugger:
         self._client._empty_command(f"debugger-{name}", timeout)
 
     def start(self, timeout: float = 60.0) -> None:
+        """Start debugging; Defold 1.13.2 reports completion in last_command_result."""
         self._run("start", timeout)
 
     def stop(self, timeout: float = 10.0) -> None:
@@ -673,6 +711,7 @@ class Client:
         self._cached_engine_identity = self._read_cached_engine_identity()
         self._remotery_url: Optional[str] = self._read_cached_remotery_url()
         self._last_build_had_engine_service_port: Optional[bool] = None
+        self._last_command_result: Optional[BuildResult] = None
         self._lifecycle_events = []
         self._openapi_document: Optional[dict] = None
         self.commands = Commands(self)
@@ -681,6 +720,17 @@ class Client:
         self.reference = Reference(self)
         self.preview = Preview(self)
         self.preferences = Preferences(self)
+
+    @property
+    def last_command_result(self) -> Optional[BuildResult]:
+        """Latest build/command result, including failures; None before a response.
+
+        Build-and-run helpers still return an engine client. HTML5, hot reload,
+        and debugger helpers retain their existing None return. Read this
+        property immediately after those calls to inspect completion and issues.
+        It is cleared when the next command is sent, including transport failure.
+        """
+        return self._last_command_result
 
     @staticmethod
     def _read_editor_port(project_root: Path) -> int:
@@ -1038,12 +1088,47 @@ class Client:
         check_cancelled()
         self._require_command(command)
         url = f"{self.base_url}/command/{command}"
+        self._last_command_result = None
         status, body = request_raw(url, method="POST", timeout=timeout)
-        if status < 200 or status >= 300:
-            raise CommandError(f"{command} failed with HTTP {status}: {body.decode('utf-8', 'replace')}")
+        if body.strip() in (b"", b"200 OK", b"202 Accepted"):
+            if status < 200 or status >= 300:
+                raise CommandError(f"{command} failed with HTTP {status}")
+            self._last_command_result = BuildResult(command, status, False, None, (), None, {})
+            return
+        try:
+            response = json.loads(body)
+        except (ValueError, UnicodeDecodeError) as exc:
+            if status < 200 or status >= 300:
+                raise CommandError(f"{command} failed with HTTP {status}: {body.decode('utf-8', 'replace')}") from exc
+            raise HttpError("POST", url, "invalid command result JSON", status=status) from exc
+        self._accept_build_result(command, url, status, response)
+
+    def _accept_build_result(self, command: str, url: str, status: int, response: Any) -> BuildResult:
+        try:
+            if not isinstance(response, Mapping) or type(response.get("success")) is not bool:
+                raise ValueError("build result requires a boolean success")
+            raw_issues = response.get("issues", [])
+            if not isinstance(raw_issues, list) or any(not isinstance(item, Mapping) for item in raw_issues):
+                raise ValueError("build result issues must be an array of objects")
+            issues = tuple(BuildIssue.from_raw(item) for item in raw_issues)
+            target_url = None
+            if "target" in response:
+                target = response["target"]
+                if not isinstance(target, Mapping) or not isinstance(target.get("url"), str) or not target["url"]:
+                    raise ValueError("build result target requires a non-empty URL string")
+                target_url = target["url"]
+        except ValueError as exc:
+            raise HttpError("POST", url, str(exc), status=status) from exc
+        result = BuildResult(command, status, True, response["success"], issues, target_url, dict(response))
+        self._last_command_result = result
+        if status < 200 or status >= 300 or not result.success:
+            raise BuildError(issues, result=result)
+        return result
 
     def _json_command(self, command: str, timeout: float) -> tuple[int, dict]:
+        check_cancelled()
         self._require_command(command)
+        self._last_command_result = None
         return request_json(f"{self.base_url}/command/{command}", method="POST", timeout=timeout)
 
     def connect_engine(
@@ -1125,9 +1210,14 @@ class Client:
 
 
     def build_and_run_html5(self, *, timeout: float = 60.0) -> None:
+        """Build and launch HTML5; inspect last_command_result for completion.
+
+        Defold 1.13.1 only acknowledges this request. Defold 1.13.2 waits for
+        completion and raises BuildError with source diagnostics on failure.
+        """
         self._empty_command("build-html5", timeout)
 
-    def _build_and_run_command(self, command: str, timeout: float = 60.0) -> None:
+    def _build_and_run_command(self, command: str, timeout: float = 60.0) -> BuildResult:
         """Execute a desktop build-and-run command and await endpoint registration."""
         check_cancelled()
         if command not in {"build", "clean-build"}:
@@ -1140,15 +1230,14 @@ class Client:
         previous_port = self._engine_service_port_value()
         if previous_port is not None:
             self._engine_service_port = previous_port
+        self._last_command_result = None
+        url = f"{self.base_url}/command/{command}"
         try:
-            status, response = request_json(f"{self.base_url}/command/{command}", method="POST", timeout=timeout)
+            status, response = request_json(url, method="POST", timeout=timeout)
+            result = self._accept_build_result(command, url, status, response)
         except Exception as exc:
             self._record_lifecycle("editor_build_failed", error=str(exc))
             raise
-        if status >= 400 or not response.get("success"):
-            issues = tuple(BuildIssue.from_raw(item) for item in response.get("issues", ()) if isinstance(item, Mapping))
-            self._record_lifecycle("editor_build_failed", issues=issues)
-            raise BuildError(issues)
         self._record_lifecycle("editor_build_completed")
 
         try:
@@ -1167,6 +1256,7 @@ class Client:
         self._record_lifecycle("new_engine_registered")
         self._last_build_had_engine_service_port = self._latest_registration_has_engine_service_port()
         cancellable_sleep(0.2)
+        return result
 
     def _console_lines(self) -> list:
         """Return current editor console lines."""
@@ -1582,6 +1672,7 @@ __all__ = [
     "AutomationBridgeUpdateResult",
     "BuildError",
     "BuildIssue",
+    "BuildResult",
     "Client",
     "CommandError",
     "CommandInfo",

--- a/automation_bridge/automation-bridge-python/best_practices.py
+++ b/automation_bridge/automation-bridge-python/best_practices.py
@@ -90,7 +90,7 @@ def inspect_editor_services(project: editor.Client) -> None:
 
 
 def build_owned_game(project: editor.Client) -> engine.Client:
-    """Build a fresh engine and declare the features required by the script."""
+    """Compile and launch directly; a separate compile call is unnecessary."""
     return project.build_and_run(
         required_capabilities=(
             "scene",
@@ -101,6 +101,11 @@ def build_owned_game(project: editor.Client) -> engine.Client:
             "screenshot",
         ),
     )
+
+
+def check_compilation(project: editor.Client) -> editor.BuildResult:
+    """Check resources and Lua without launching; requires Defold 1.13.2."""
+    return project.compile()
 
 
 def connect_to_existing_game(project: editor.Client) -> engine.Client:

--- a/tests/editor_http_fixture.py
+++ b/tests/editor_http_fixture.py
@@ -1,0 +1,56 @@
+"""Local editor HTTP fixture for exercising discovery and command transport."""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+class EditorHttpFixture:
+    def __init__(self, document, respond):
+        self.document = document
+        self.respond = respond
+        self.requests = []
+
+    def __enter__(self):
+        fixture = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.dispatch()
+
+            def do_POST(self):
+                self.dispatch()
+
+            def log_message(self, *args):
+                pass
+
+            def dispatch(self):
+                body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+                request = {"method": self.command, "path": self.path,
+                           "headers": dict(self.headers), "body": body}
+                fixture.requests.append(request)
+                if self.command == "GET" and self.path == "/openapi.json":
+                    status, response = 200, fixture.document
+                else:
+                    status, response = fixture.respond(request)
+                if isinstance(response, bytes):
+                    content_type = "text/plain"
+                else:
+                    response = json.dumps(response).encode("utf-8")
+                    content_type = "application/json"
+                self.send_response(status)
+                self.send_header("Content-Type", content_type)
+                self.send_header("Content-Length", str(len(response)))
+                self.end_headers()
+                self.wfile.write(response)
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.port = self.server.server_port
+        self.thread = threading.Thread(target=self.server.serve_forever, kwargs={"poll_interval": 0.01}, daemon=True)
+        self.thread.start()
+        return self
+
+    def __exit__(self, *args):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=1)

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,16 @@
+# Editor API fixtures
+
+`editor_openapi_1_13_1.json` records the legacy command enum.
+`editor_openapi_1_13_2.json` records individual command paths, focus, and Bob
+authentication/request schemas. These are reduced OpenAPI fixtures: unrelated
+documentation and most UI-only commands are omitted from the newer fixture.
+The deprecated `/command/build` alias is deliberately absent in 1.13.2 discovery.
+Both API documents use `info.version = "1.0"`; it is not the Defold version.
+
+Reference contracts are in Defold's `editor/src/clj/editor/command_requests.clj`,
+`editor/src/clj/editor/web_server.clj`, and
+`editor/test/integration/web_server_test.clj`. The 1.13.1 contract comes from its
+release tag; the 1.13.2 contract comes from the development source introducing
+compile/run and Bob. Some early 1.13.2 alpha installations may lack these additions.
+Update the fixtures when those source contracts change, without deriving expected
+paths from the Python wrapper's own supported-command constants.

--- a/tests/fixtures/editor_openapi_1_13_1.json
+++ b/tests/fixtures/editor_openapi_1_13_1.json
@@ -1,5 +1,6 @@
 {
   "openapi": "3.0.3",
+  "info": {"title": "Defold Editor HTTP Server", "version": "1.0"},
   "paths": {
     "/console": {"get": {}},
     "/console/stream": {"get": {}},
@@ -12,7 +13,10 @@
         "parameters": [
           {
             "name": "command",
+            "in": "path",
+            "required": true,
             "schema": {
+              "type": "string",
               "enum": [
                 "build",
                 "clean-build",

--- a/tests/fixtures/editor_openapi_1_13_2.json
+++ b/tests/fixtures/editor_openapi_1_13_2.json
@@ -1,0 +1,65 @@
+{
+  "openapi": "3.0.3",
+  "info": {"title": "Defold Editor HTTP Server", "version": "1.0"},
+  "components": {
+    "securitySchemes": {
+      "token": {"type": "http", "scheme": "bearer", "bearerFormat": "opaque"}
+    }
+  },
+  "paths": {
+    "/console": {"get": {}},
+    "/console/stream": {"get": {}},
+    "/prefs/{path}": {"get": {}, "post": {}},
+    "/ref": {"get": {}},
+    "/preview/{path}": {"get": {}},
+    "/eval": {"post": {}},
+    "/bob": {
+      "post": {
+        "summary": "Bundle or build the project with Bob options",
+        "description": "Does not launch. Output goes to /console. Option keys are Bob CLI options without --. Use arrays for repeatable options. Print help with options.help=true",
+        "security": [{"token": []}],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "options": {"type": "object"},
+                  "commands": {"type": "array", "items": {"type": "string"}}
+                }
+              }
+            }
+          }
+        },
+        "responses": {"default": {"description": "Build result"}}
+      }
+    },
+    "/command/run": {
+      "post": {
+        "summary": "Compile and launch the project.",
+        "parameters": [
+          {"name": "focus", "in": "query", "description": "Whether the launched game takes focus.", "schema": {"type": "boolean", "default": true}}
+        ],
+        "responses": {"default": {"description": "Build result"}}
+      }
+    },
+    "/command/compile": {"post": {"summary": "Compile the project without launching or bundling.", "responses": {"default": {"description": "Build result"}}}},
+    "/command/clean-build": {"post": {"summary": "Clears build caches and rebuilds. Use only if builds fail oddly or miss changes.", "responses": {"default": {"description": "Build result"}}}},
+    "/command/build-html5": {"post": {"summary": "Build and launch HTML5 in a web browser.", "responses": {"default": {"description": "Build result"}}}},
+    "/command/hot-reload": {"post": {"summary": "Hot reload changed resources.", "responses": {"default": {"description": "Build result"}}}},
+    "/command/debugger-start": {"post": {"summary": "Start the debugger.", "responses": {"default": {"description": "Build result"}}}},
+    "/command/fetch-libraries": {"post": {"summary": "Fetch project libraries."}},
+    "/command/rebundle": {"post": {"summary": "Repeat the last bundle operation."}},
+    "/command/reload-extensions": {"post": {"summary": "Reload editor extensions."}},
+    "/command/reload-stylesheets": {"post": {"summary": "Reload editor stylesheets."}},
+    "/command/debugger-stop": {"post": {}},
+    "/command/debugger-break": {"post": {}},
+    "/command/debugger-continue": {"post": {}},
+    "/command/debugger-detach": {"post": {}},
+    "/command/debugger-step-into": {"post": {}},
+    "/command/debugger-step-out": {"post": {}},
+    "/command/debugger-step-over": {"post": {}},
+    "/command/documentation": {"post": {"summary": "Open documentation."}}
+  }
+}

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -168,6 +168,41 @@ def _count_light_pixels_in_rect(path, rect):
 
 
 class EngineClientUnitTest(unittest.TestCase):
+    def test_editor_discovery_accepts_individual_command_paths(self):
+        project = EditorApiClient(".", port=12345)
+        project._openapi_document = {"paths": {
+            "/command/run": {"post": {"summary": "Compile and launch", "parameters": [
+                {"name": "focus", "in": "query", "schema": {"type": "boolean", "default": True}},
+            ]}},
+            "/command/compile": {"post": {"summary": "Compile without launching"}},
+            "/command/documentation": {"post": {}},
+        }}
+        self.assertEqual(["compile", "run"], [item.name for item in project.commands.catalog()])
+        self.assertTrue(project.commands.supports("run", parameter="focus"))
+        self.assertFalse(project.commands.supports("compile", parameter="focus"))
+        self.assertFalse(project.commands.supports("build"))
+        self.assertFalse(project.commands.supports("documentation"))
+        self.assertEqual("Compile and launch", project._require_command("run").summary)
+        self.assertEqual("/command/compile", project._require_command("compile").path)
+
+    def test_editor_discovery_preserves_legacy_commands_and_version_guidance(self):
+        project = EditorApiClient(".", port=12345)
+        project._openapi_document = EDITOR_OPENAPI
+        self.assertTrue(project.commands.supports("build"))
+        self.assertFalse(project.commands.supports("build", parameter="focus"))
+        for name in ("compile", "run"):
+            with self.subTest(name=name), self.assertRaisesRegex(editor.UnsupportedOperationError, "supported from Defold 1.13.2") as error:
+                project._require_command(name)
+            self.assertEqual("1.13.2", error.exception.minimum_version)
+
+    def test_editor_discovery_refreshes_without_executing_commands(self):
+        project = EditorApiClient(".", port=12345)
+        project._openapi_document = EDITOR_OPENAPI
+        with mock.patch("automation_bridge.editor.request_json", return_value=(200, {"paths": {"/command/compile": {"post": {}}}})) as request:
+            self.assertFalse(project.commands.supports("compile"))
+            self.assertEqual(["compile"], [item.name for item in project.commands.catalog(refresh=True)])
+        request.assert_called_once_with(project.base_url + "/openapi.json", timeout=10.0)
+
     def test_required_runtime_does_not_silently_skip_missing_editor(self):
         with mock.patch.dict(os.environ, {"AUTOMATION_BRIDGE_REQUIRE_RUNTIME": "1"}):
             with self.assertRaisesRegex(RuntimeError, "missing editor"):
@@ -1107,7 +1142,7 @@ class EngineClientUnitTest(unittest.TestCase):
 
         parameters = EDITOR_OPENAPI["paths"]["/command/{command}"]["post"]["parameters"]
         advertised = set(parameters[0]["schema"]["enum"])
-        self.assertEqual(advertised, editor._SUPPORTED_COMMANDS | editor._EXCLUDED_COMMANDS)
+        self.assertEqual(advertised | {"compile", "run"}, editor._SUPPORTED_COMMANDS | editor._EXCLUDED_COMMANDS)
         self.assertFalse(editor._SUPPORTED_COMMANDS & editor._EXCLUDED_COMMANDS)
         self.assertEqual({("/eval", "post")}, editor._EXCLUDED_PATHS)
         advertised_paths = {

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -368,6 +368,7 @@ class EngineClientUnitTest(unittest.TestCase):
 
     def test_editor_workflows_forward_explicit_session_identity(self):
         project = EditorApiClient(".", port=1234)
+        project._openapi_document = EDITOR_OPENAPI
         with mock.patch.object(EngineClient, "_from_editor") as connect:
             for method in (project.connect_engine, project.build_and_run, project.clean_build_and_run):
                 method(client_id="agent-a", session_id="task-1")
@@ -391,6 +392,7 @@ class EngineClientUnitTest(unittest.TestCase):
 
     def test_invalid_session_identity_is_rejected_before_build(self):
         project = EditorApiClient(".", port=1234)
+        project._openapi_document = EDITOR_OPENAPI
         with mock.patch.object(project, "_build_and_run_command") as build:
             for value in (False, "", 1):
                 with self.subTest(value=value), self.assertRaises(ValueError):
@@ -1515,6 +1517,7 @@ class EngineClientUnitTest(unittest.TestCase):
 
     def test_editor_build_workflows_delegate_with_explicit_command_names(self):
         project = EditorApiClient(".", port=12345)
+        project._openapi_document = EDITOR_OPENAPI
         sentinel = object()
         with mock.patch.object(EngineClient, "_from_editor", return_value=sentinel) as connect:
             self.assertIs(sentinel, project.build_and_run(timeout=12, required_capabilities=("scene",)))
@@ -1523,6 +1526,78 @@ class EngineClientUnitTest(unittest.TestCase):
         self.assertEqual("build", connect.call_args_list[0].kwargs["build_command"])
         self.assertEqual("clean-build", connect.call_args_list[1].kwargs["build_command"])
         self.assertIsNone(connect.call_args_list[2].kwargs["build_command"])
+
+    def test_editor_compile_never_enters_engine_lifecycle(self):
+        project = EditorApiClient(".", port=12345)
+        project._openapi_document = {"paths": {"/command/compile": {"post": {}}}}
+        with mock.patch("automation_bridge.editor.request_json", return_value=(200, {"success": True, "issues": []})) as request, \
+             mock.patch.object(EngineClient, "_from_editor") as bootstrap, \
+             mock.patch.object(project, "_console_lines") as console:
+            result = project.compile(timeout=12)
+        self.assertIs(project.last_command_result, result)
+        self.assertTrue(result.completed)
+        self.assertEqual("compile", result.command)
+        request.assert_called_once_with(project.base_url + "/command/compile", method="POST", timeout=12)
+        bootstrap.assert_not_called()
+        console.assert_not_called()
+
+    def test_editor_compile_and_focus_reject_legacy_before_mutation(self):
+        project = EditorApiClient(".", port=12345)
+        project._openapi_document = EDITOR_OPENAPI
+        with mock.patch.object(EngineClient, "_from_editor") as bootstrap, \
+             mock.patch("automation_bridge.editor.request_json") as request:
+            for operation in (project.compile, lambda: project.build_and_run(focus=False)):
+                with self.assertRaisesRegex(editor.UnsupportedOperationError, "supported from Defold 1.13.2"):
+                    operation()
+        request.assert_not_called()
+        bootstrap.assert_not_called()
+        with mock.patch.object(EngineClient, "_from_editor") as bootstrap:
+            project.build_and_run(focus=True)
+        self.assertEqual("build", bootstrap.call_args.kwargs["build_command"])
+        self.assertNotIn("focus", bootstrap.call_args.kwargs)
+
+    def test_editor_run_negotiates_focus_and_prefers_new_command(self):
+        project = EditorApiClient(".", port=12345)
+        project._openapi_document = {"paths": {"/command/run": {"post": {"parameters": [
+            {"name": "focus", "in": "query", "schema": {"type": "boolean"}},
+        ]}}, "/command/build": {"post": {}}}}
+        for supplied, expected in ((None, False), (False, False), (True, True)):
+            with self.subTest(focus=supplied), mock.patch.object(EngineClient, "_from_editor") as bootstrap:
+                project.build_and_run(focus=supplied)
+            self.assertEqual("run", bootstrap.call_args.kwargs["build_command"])
+            self.assertIs(expected, bootstrap.call_args.kwargs["focus"])
+            with mock.patch.object(project, "_console_lines", return_value=[]), \
+                 mock.patch.object(project, "_engine_service_port_value", return_value=None), \
+                 mock.patch.object(project, "_has_fresh_endpoint_registration", return_value=True), \
+                 mock.patch.object(project, "_latest_registration_has_engine_service_port", return_value=True), \
+                 mock.patch("automation_bridge.editor.cancellable_sleep"), \
+                 mock.patch("automation_bridge.editor.request_json", return_value=(200, {"success": True, "issues": []})) as request:
+                project._build_and_run_command("run", focus=expected)
+            self.assertEqual(project.base_url + "/command/run?focus=" + str(expected).lower(), request.call_args.args[0])
+            self.assertEqual(1, request.call_count)
+
+    def test_editor_run_validates_focus_and_clean_build_before_bootstrap(self):
+        project = EditorApiClient(".", port=12345)
+        project._openapi_document = {"paths": {}}
+        with mock.patch.object(EngineClient, "_from_editor") as bootstrap:
+            for focus in (0, 1, "false", [], {}):
+                with self.subTest(focus=focus), self.assertRaisesRegex(ValueError, "focus"):
+                    project.build_and_run(focus=focus)
+            with self.assertRaises(editor.UnsupportedOperationError):
+                project.clean_build_and_run()
+            with self.assertRaises(editor.UnsupportedOperationError):
+                project.build_and_run()
+        bootstrap.assert_not_called()
+
+    def test_editor_run_keeps_focus_during_stale_build_recovery(self):
+        project = EditorApiClient(".", port=12345)
+        sentinel = object()
+        with mock.patch.object(EngineClient, "_close_candidate_engine_ports"), \
+             mock.patch("automation_bridge.client.cancellable_sleep"), \
+             mock.patch.object(EngineClient, "_wait_for_bridge", return_value=sentinel), \
+             mock.patch.object(project, "_build_and_run_command") as build:
+            self.assertIs(sentinel, EngineClient._recover_after_stale_build(project, lambda: None, 5, "run", focus=False))
+        build.assert_called_once_with("run", timeout=5, focus=False)
 
     def test_editor_preferences_catalog_and_custom_paths(self):
         project = EditorApiClient(".", port=12345)

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -1679,6 +1679,104 @@ class EngineClientUnitTest(unittest.TestCase):
             self.assertIs(sentinel, EngineClient._recover_after_stale_build(project, lambda: None, 5, "run", focus=False))
         build.assert_called_once_with("run", timeout=5, focus=False)
 
+    def test_editor_target_urls_must_match_the_local_engine_transport(self):
+        for url in ("http://127.0.0.1:3456", "http://localhost:3456/", "http://LOCALHOST:3456"):
+            self.assertEqual(3456, EditorApiClient._local_target_port(url))
+        for url in ("https://localhost:3456", "http://example.test:3456", "http://127.0.0.2:3456",
+                    "http://[::1]:3456", "http://localhost", "http://localhost:0", "http://localhost:65536",
+                    "http://localhost:bad", "http://localhost:3456/other", "http://user:secret@localhost:3456",
+                    "http://localhost:3456?x=1", "http://localhost:3456#fragment", " http://localhost:3456"):
+            with self.subTest(url=url), self.assertRaisesRegex(editor.UnsupportedOperationError, "local engine client"):
+                EditorApiClient._local_target_port(url)
+
+    def test_editor_reported_target_skips_console_registration_wait_and_resets_on_next_build(self):
+        with tempfile.TemporaryDirectory() as root:
+            project = EditorApiClient(root, port=12345)
+            project._openapi_document = {"paths": {"/command/run": {"post": {}}}}
+            payload = {"success": True, "issues": [], "target": {"url": "http://127.0.0.1:3456"}}
+            with mock.patch.object(project, "_console_lines", return_value=[]), \
+                 mock.patch.object(project, "_engine_service_port_value", return_value=None), \
+                 mock.patch.object(project, "_has_fresh_endpoint_registration", return_value=True) as registration, \
+                 mock.patch.object(project, "_latest_registration_has_engine_service_port", return_value=True), \
+                 mock.patch("automation_bridge.editor.cancellable_sleep"), \
+                 mock.patch("automation_bridge.editor.request_json", return_value=(200, payload)):
+                result = project._build_and_run_command("run")
+                self.assertEqual("http://127.0.0.1:3456", result.target_url)
+                self.assertEqual(3456, project._last_build_target_port)
+                registration.assert_not_called()
+                del payload["target"]
+                project._build_and_run_command("run")
+                self.assertIsNone(project._last_build_target_port)
+                registration.assert_called_once()
+
+    def test_editor_bootstrap_prefers_reported_target_and_preserves_matching_profiler(self):
+        health = {"version": "2", "capabilities": ["runtime.health", "scene"],
+                  "identity": {"engine_instance_id": "engine:new", "project_identity": "project:test"}}
+        for console_port, expected_profiler in ((3456, "ws://127.0.0.1:5555/rmt"), (9876, None)):
+            with self.subTest(console_port=console_port), tempfile.TemporaryDirectory() as root:
+                project = EditorApiClient(root, port=12345)
+                project._openapi_document = {"paths": {"/command/run": {"post": {}}}}
+                lines = [f"INFO:ENGINE: Engine service started on port {console_port}",
+                         "INFO:ENGINE: Initialized Remotery (ws://127.0.0.1:5555/rmt)",
+                         "INFO:ENGINE: Automation Bridge endpoint registered"]
+                with mock.patch.object(EngineClient, "_close_candidate_engine_ports"), \
+                     mock.patch.object(project, "_engine_service_port_value", return_value=None), \
+                     mock.patch.object(project, "_console_lines", return_value=lines), \
+                     mock.patch.object(EngineClient, "_request", autospec=True, return_value=health) as request, \
+                     mock.patch("automation_bridge.client.cancellable_sleep"), \
+                     mock.patch("automation_bridge.client.RuntimeLogs.start"), \
+                     mock.patch("automation_bridge.editor.request_json", return_value=(200, {"success": True, "issues": [], "target": {"url": "http://localhost:3456"}})) as build:
+                    bridge = project.build_and_run(required_capabilities=("scene",), client_id="agent-a", session_id="task-1")
+                self.assertEqual(3456, bridge.port)
+                self.assertTrue(bridge.owns_engine)
+                self.assertEqual(expected_profiler, bridge.profiler_url)
+                self.assertEqual("engine:new", bridge.engine_instance_id)
+                self.assertEqual("task-1", bridge.session_info()["session_id"])
+                self.assertEqual(3456, project._cached_engine_identity["port"])
+                self.assertTrue(all(call.args[0].port == 3456 for call in request.call_args_list))
+                build.assert_called_once()
+                bridge.close()
+
+    def test_editor_reported_target_never_falls_back_or_relaunches_after_health_failure(self):
+        with tempfile.TemporaryDirectory() as root:
+            project = EditorApiClient(root, port=12345)
+            project._openapi_document = {"paths": {"/command/run": {"post": {}}}}
+            project._cached_engine_identity = {"port": 3456, "project_identity": "project:expected"}
+            rejected = [
+                {"version": "2", "identity": {}},
+                {"version": "2", "identity": {"engine_instance_id": "engine:other", "project_identity": "project:other"}},
+            ]
+            for health in rejected:
+                with self.subTest(health=health), \
+                     mock.patch.object(EngineClient, "_close_candidate_engine_ports"), \
+                     mock.patch.object(project, "_engine_service_port_value", return_value=None), \
+                     mock.patch.object(project, "_console_lines", return_value=[]), \
+                     mock.patch.object(EngineClient, "_request", autospec=True, return_value=health) as request, \
+                     mock.patch.object(EngineClient, "_recover_after_stale_build") as recover, \
+                     mock.patch("automation_bridge.client.cancellable_sleep"), \
+                     mock.patch("automation_bridge.editor.request_json", return_value=(200, {"success": True, "issues": [], "target": {"url": "http://localhost:3456"}})) as build:
+                    with self.assertRaisesRegex(WaitTimeoutError, "reported target"):
+                        project.build_and_run(timeout=0.002)
+                self.assertTrue(request.called)
+                self.assertTrue(all(call.args[0].port == 3456 for call in request.call_args_list))
+                recover.assert_not_called()
+                build.assert_called_once()
+                self.assertEqual("project:expected", project._cached_engine_identity["project_identity"])
+
+    def test_editor_reported_target_still_requires_native_capabilities(self):
+        with tempfile.TemporaryDirectory() as root:
+            project = EditorApiClient(root, port=12345)
+            project._openapi_document = {"paths": {"/command/run": {"post": {}}}}
+            with mock.patch.object(EngineClient, "_close_candidate_engine_ports"), \
+                 mock.patch.object(project, "_engine_service_port_value", return_value=None), \
+                 mock.patch.object(project, "_console_lines", return_value=[]), \
+                 mock.patch.object(EngineClient, "_request", return_value={"version": "2", "capabilities": []}), \
+                 mock.patch("automation_bridge.client.cancellable_sleep"), \
+                 mock.patch("automation_bridge.editor.request_json", return_value=(200, {"success": True, "issues": [], "target": {"url": "http://localhost:3456"}})) as build:
+                with self.assertRaises(UnsupportedCapabilityError):
+                    project.build_and_run(required_capabilities=("scene",))
+            build.assert_called_once()
+
     def test_editor_preferences_catalog_and_custom_paths(self):
         project = EditorApiClient(".", port=12345)
         project._openapi_document = EDITOR_OPENAPI

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -1455,6 +1455,63 @@ class EngineClientUnitTest(unittest.TestCase):
         self.assertEqual("/main/main.script", actual.resource)
         self.assertEqual((7, 3), (actual.range.start.line, actual.range.start.character))
         self.assertEqual((7, 8), (actual.range.end.line, actual.range.end.character))
+        self.assertIs(project.last_command_result, raised.exception.result)
+        self.assertFalse(raised.exception.result.success)
+
+    def test_editor_legacy_acknowledgements_do_not_claim_completion(self):
+        project = EditorApiClient(".", port=12345)
+        project._openapi_document = EDITOR_OPENAPI
+        for status, body in ((202, b""), (202, b"202 Accepted\n"), (200, b"200 OK\n")):
+            with self.subTest(body=body), mock.patch("automation_bridge.editor.request_raw", return_value=(status, body)):
+                self.assertIsNone(project.commands.hot_reload())
+            result = project.last_command_result
+            self.assertEqual(("hot-reload", status, False, None), (result.command, result.status, result.completed, result.success))
+
+    def test_editor_completion_retains_warnings_target_and_additional_fields(self):
+        project = EditorApiClient(".", port=12345)
+        project._openapi_document = EDITOR_OPENAPI
+        payload = {"success": True, "issues": [{"severity": "warning", "message": "unused variable"}],
+                   "target": {"url": "http://localhost:3456"}, "future_metadata": "retained"}
+        for operation in (project.commands.hot_reload, project.debugger.start, project.build_and_run_html5):
+            with mock.patch("automation_bridge.editor.request_raw", return_value=(200, json.dumps(payload).encode())):
+                self.assertIsNone(operation())
+            result = project.last_command_result
+            self.assertTrue(result.completed)
+            self.assertTrue(result.success)
+            self.assertEqual("warning", result.issues[0].severity)
+            self.assertEqual("http://localhost:3456", result.target_url)
+            self.assertEqual("retained", result.raw["future_metadata"])
+        with mock.patch("automation_bridge.editor.request_raw", side_effect=editor.HttpError("POST", project.base_url, "unavailable")):
+            with self.assertRaises(editor.HttpError):
+                project.commands.hot_reload()
+        self.assertIsNone(project.last_command_result)
+
+    def test_editor_completion_surfaces_build_failure_and_missing_target(self):
+        project = EditorApiClient(".", port=12345)
+        project._openapi_document = EDITOR_OPENAPI
+        for status, success in ((200, True), (422, False), (200, False)):
+            with mock.patch("automation_bridge.editor.request_raw", return_value=(status, json.dumps({"success": success, "issues": []}).encode())):
+                if success:
+                    project.commands.hot_reload()
+                else:
+                    with self.assertRaises(editor.BuildError) as error:
+                        project.commands.hot_reload()
+                    self.assertIs(project.last_command_result, error.exception.result)
+            self.assertIsNone(project.last_command_result.target_url)
+            self.assertEqual(success, project.last_command_result.success)
+
+    def test_editor_rejects_malformed_completion_evidence(self):
+        project = EditorApiClient(".", port=12345)
+        project._openapi_document = EDITOR_OPENAPI
+        payloads = [[], {}, {"success": "false"}, {"success": True, "issues": None},
+                    {"success": True, "issues": [None]}, {"success": True, "target": {}},
+                    {"success": True, "target": {"url": 123}},
+                    {"success": True, "issues": [{"severity": "error", "message": "broken", "range": {"start": {"line": "7", "character": 0}, "end": {"line": 7, "character": 1}}}]}]
+        for payload in payloads:
+            with self.subTest(payload=payload), mock.patch("automation_bridge.editor.request_raw", return_value=(200, json.dumps(payload).encode())):
+                with self.assertRaises(editor.HttpError):
+                    project.commands.hot_reload()
+            self.assertIsNone(project.last_command_result)
 
     def test_editor_build_workflows_delegate_with_explicit_command_names(self):
         project = EditorApiClient(".", port=12345)

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -1152,7 +1152,7 @@ class EngineClientUnitTest(unittest.TestCase):
             for path, operations in EDITOR_OPENAPI["paths"].items()
             for method in operations
         }
-        self.assertEqual(advertised_paths, editor._SUPPORTED_PATHS | editor._EXCLUDED_PATHS)
+        self.assertEqual(advertised_paths | {("/bob", "post")}, editor._SUPPORTED_PATHS | editor._EXCLUDED_PATHS)
 
     def test_every_editor_command_wrapper_uses_its_advertised_command(self):
         project = EditorApiClient(".", port=12345)
@@ -1540,6 +1540,86 @@ class EngineClientUnitTest(unittest.TestCase):
         request.assert_called_once_with(project.base_url + "/command/compile", method="POST", timeout=12)
         bootstrap.assert_not_called()
         console.assert_not_called()
+
+    def test_editor_bob_sends_options_and_reads_each_session_token(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / ".internal").mkdir()
+            token_path = root / ".internal/editor.token"
+            project = EditorApiClient(root, port=12345)
+            project._openapi_document = {"paths": {"/bob": {"post": {}}}}
+            with mock.patch("automation_bridge.editor.request_json", return_value=(200, {"success": True, "issues": []})) as request, \
+                 mock.patch.object(EngineClient, "_from_editor") as bootstrap:
+                for token in ("first-session", "second-session"):
+                    token_path.write_text(token + "\n", encoding="utf-8")
+                    result = project.bob(options={"platform": "wasm-web", "archive": True, "architectures": ["wasm-web", "js-web"]}, commands=("build", "bundle"), timeout=90)
+                    self.assertEqual("Bearer " + token, request.call_args.kwargs["headers"]["Authorization"])
+                    self.assertEqual("application/json", request.call_args.kwargs["headers"]["Content-Type"])
+                    self.assertEqual(90, request.call_args.kwargs["timeout"])
+                    self.assertEqual(project.base_url + "/bob", request.call_args.args[0])
+                    self.assertEqual(["build", "bundle"], json.loads(request.call_args.kwargs["data"])["commands"])
+                    self.assertEqual(["wasm-web", "js-web"], json.loads(request.call_args.kwargs["data"])["options"]["architectures"])
+                    self.assertIs(project.last_command_result, result)
+                    self.assertTrue(result.success)
+                    self.assertEqual("bob", result.command)
+            self.assertEqual(2, request.call_count)
+            bootstrap.assert_not_called()
+
+    def test_editor_bob_rejects_unsupported_and_malformed_input_before_request(self):
+        project = EditorApiClient(".", port=12345)
+        project._openapi_document = EDITOR_OPENAPI
+        with mock.patch("automation_bridge.editor.request_json") as request:
+            with self.assertRaisesRegex(editor.UnsupportedOperationError, "supported from Defold 1.13.2"):
+                project.bob()
+            for options in ([], "--help", {3: "value"}, {"value": float("nan")}, {"value": object()}):
+                with self.subTest(options=options), self.assertRaises(ValueError):
+                    project.bob(options=options)
+            for commands in (None, "build", b"build", [False], 1):
+                with self.subTest(commands=commands), self.assertRaises(ValueError):
+                    project.bob(commands=commands)
+        request.assert_not_called()
+
+    def test_editor_bob_missing_credentials_and_rejections_do_not_leak_token_or_retry(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            project = EditorApiClient(root, port=12345)
+            project._openapi_document = {"paths": {"/bob": {"post": {}}}}
+            with mock.patch("automation_bridge.editor.request_json") as request:
+                with self.assertRaisesRegex(editor.CommandError, "editor.token"):
+                    project.bob()
+            request.assert_not_called()
+            (root / ".internal").mkdir()
+            token = "private-test-token"
+            (root / ".internal/editor.token").write_text(token, encoding="utf-8")
+            failures = [(401, {"error": token}), (403, {"error": token}),
+                        editor.HttpError("POST", project.base_url + "/bob", token, status=401)]
+            for failure in failures:
+                kwargs = {"side_effect": failure} if isinstance(failure, Exception) else {"return_value": failure}
+                with mock.patch("automation_bridge.editor.request_json", **kwargs) as request:
+                    with self.assertRaisesRegex(editor.CommandError, "authentication was rejected") as error:
+                        project.bob()
+                self.assertNotIn(token, str(error.exception))
+                self.assertIsNone(error.exception.__cause__)
+                request.assert_called_once()
+                self.assertIsNone(project.last_command_result)
+
+    def test_editor_bob_preserves_build_diagnostics_without_retrying_transport(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / ".internal").mkdir()
+            (root / ".internal/editor.token").write_text("test-session", encoding="utf-8")
+            project = EditorApiClient(root, port=12345)
+            project._openapi_document = {"paths": {"/bob": {"post": {}}}}
+            payload = {"success": False, "issues": [{"severity": "error", "message": "invalid option"}]}
+            with mock.patch("automation_bridge.editor.request_json", return_value=(422, payload)):
+                with self.assertRaises(editor.BuildError) as error:
+                    project.bob(options={"help": True})
+            self.assertIs(project.last_command_result, error.exception.result)
+            with mock.patch("automation_bridge.editor.request_json", side_effect=editor.HttpError("POST", project.base_url, "timed out")) as request:
+                with self.assertRaises(editor.HttpError):
+                    project.bob()
+            request.assert_called_once()
+            self.assertIsNone(project.last_command_result)
 
     def test_editor_compile_and_focus_reject_legacy_before_mutation(self):
         project = EditorApiClient(".", port=12345)

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -18,6 +18,8 @@ import zlib
 from pathlib import Path
 from unittest import mock
 
+from tests.editor_http_fixture import EditorHttpFixture
+
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "automation_bridge" / "automation-bridge-python"))
@@ -61,7 +63,8 @@ from automation_bridge.remotery import (  # noqa: E402
 )
 
 
-EDITOR_OPENAPI = json.loads((ROOT / "tests/fixtures/editor_openapi.json").read_text(encoding="utf-8"))
+EDITOR_OPENAPI = json.loads((ROOT / "tests/fixtures/editor_openapi_1_13_1.json").read_text(encoding="utf-8"))
+EDITOR_OPENAPI_1_13_2 = json.loads((ROOT / "tests/fixtures/editor_openapi_1_13_2.json").read_text(encoding="utf-8"))
 
 
 def _read_automation_bridge_png(path):
@@ -3180,6 +3183,125 @@ class EngineClientUnitTest(unittest.TestCase):
             )
 
 
+class EditorCompatibilityUnitTest(unittest.TestCase):
+    def test_versioned_discovery_uses_paths_instead_of_api_info_version(self):
+        for document, has_new_commands in ((EDITOR_OPENAPI, False), (EDITOR_OPENAPI_1_13_2, True)):
+            with self.subTest(new_api=has_new_commands), tempfile.TemporaryDirectory() as root, \
+                 EditorHttpFixture(document, lambda request: (404, b"Not Found")) as server:
+                project = EditorApiClient(root, port=server.port)
+                self.assertEqual("1.0", document["info"]["version"])
+                self.assertEqual(has_new_commands, project.commands.supports("compile"))
+                self.assertEqual(has_new_commands, project.commands.supports("run", parameter="focus"))
+                self.assertEqual(not has_new_commands, project.commands.supports("build"))
+                catalog = {item.name: item for item in project.commands.catalog()}
+                self.assertNotIn("documentation", catalog)
+                self.assertIn("clean-build", catalog)
+                if has_new_commands:
+                    self.assertEqual("boolean", catalog["run"].parameters[0]["schema"]["type"])
+                    self.assertIn("without launching", catalog["compile"].summary)
+                self.assertEqual(["/openapi.json"], [request["path"] for request in server.requests])
+
+    def test_build_and_run_over_http_for_both_versions_and_optional_target(self):
+        for document, target_present, expected_command in (
+            (EDITOR_OPENAPI, False, "/command/build"),
+            (EDITOR_OPENAPI_1_13_2, False, "/command/run?focus=false"),
+            (EDITOR_OPENAPI_1_13_2, True, "/command/run?focus=false"),
+        ):
+            with self.subTest(command=expected_command, target=target_present), tempfile.TemporaryDirectory() as root:
+                health = {"ok": True, "data": {"version": "2", "capabilities": ["scene"],
+                          "identity": {"engine_instance_id": "engine:fixture", "project_identity": "project:fixture"}}}
+                with FakeHttpServer(json.dumps(health).encode()) as native:
+                    console = []
+
+                    def respond(request):
+                        if request["method"] == "GET" and request["path"] == "/console":
+                            return 200, {"lines": console}
+                        if request["method"] == "POST" and request["path"] == expected_command:
+                            console.extend([f"INFO:ENGINE: Engine service started on port {native.port}",
+                                            "INFO:ENGINE: Automation Bridge endpoint registered"])
+                            result = {"success": True, "issues": []}
+                            if target_present:
+                                result["target"] = {"url": f"http://127.0.0.1:{native.port}"}
+                            return 200, result
+                        return 404, b"Not Found"
+
+                    with EditorHttpFixture(document, respond) as server, \
+                         mock.patch("automation_bridge.client.RuntimeLogs.start"), \
+                         mock.patch("automation_bridge.client.cancellable_sleep"), \
+                         mock.patch("automation_bridge.editor.cancellable_sleep"):
+                        project = EditorApiClient(root, port=server.port)
+                        bridge = project.build_and_run(timeout=1, required_capabilities=("scene",))
+                        self.assertEqual(native.port, bridge.port)
+                        self.assertTrue(bridge.owns_engine)
+                        self.assertEqual("engine:fixture", bridge.engine_instance_id)
+                        self.assertTrue(project.last_command_result.completed)
+                        self.assertEqual(target_present, project.last_command_result.target_url is not None)
+                        self.assertEqual([expected_command], [request["path"] for request in server.requests if request["method"] == "POST"])
+                        bridge.close()
+                self.assertEqual("/automation-bridge/v2/health", urllib.parse.urlsplit(native.request_line.split()[1]).path)
+
+    def test_legacy_http_acknowledgements_and_unsupported_features(self):
+        with tempfile.TemporaryDirectory() as root, \
+             EditorHttpFixture(EDITOR_OPENAPI, lambda request: (202, b"202 Accepted\n")) as server:
+            project = EditorApiClient(root, port=server.port)
+            for operation in (project.build_and_run_html5, project.debugger.start, project.commands.hot_reload):
+                operation()
+                self.assertFalse(project.last_command_result.completed)
+                self.assertIsNone(project.last_command_result.success)
+            sent = len(server.requests)
+            for operation in (project.compile, project.bob, lambda: project.build_and_run(focus=False)):
+                with self.assertRaisesRegex(editor.UnsupportedOperationError, "supported from Defold 1.13.2"):
+                    operation()
+            self.assertEqual(sent, len(server.requests))
+
+    def test_modern_compile_and_completion_diagnostics_over_http(self):
+        result = {"success": True, "issues": [{"severity": "warning", "message": "unused variable",
+                  "resource": "/main/main.script", "range": {"start": {"line": 2, "character": 0}, "end": {"line": 2, "character": 4}}}]}
+        with tempfile.TemporaryDirectory() as root, \
+             EditorHttpFixture(EDITOR_OPENAPI_1_13_2, lambda request: (200 if result["success"] else 422, result)) as server:
+            project = EditorApiClient(root, port=server.port)
+            for operation in (project.compile, project.build_and_run_html5, project.debugger.start, project.commands.hot_reload):
+                operation()
+                self.assertTrue(project.last_command_result.success)
+                self.assertTrue(project.last_command_result.completed)
+                issue = project.last_command_result.issues[0]
+                self.assertEqual("warning", issue.severity)
+                self.assertEqual(2, issue.range.start.line)
+            result["success"] = False
+            result["issues"][0]["severity"] = "error"
+            with self.assertRaises(editor.BuildError) as error:
+                project.compile()
+            self.assertEqual(422, error.exception.result.status)
+            self.assertEqual("/main/main.script", error.exception.issues[0].resource)
+            self.assertIs(project.last_command_result, error.exception.result)
+
+    def test_bob_authorization_json_and_plain_text_rejection_over_http(self):
+        authorized_calls = []
+
+        def respond(request):
+            if request["path"] != "/bob":
+                return 404, b"Not Found"
+            if request["headers"].get("Authorization") != "Bearer current-session":
+                return 401, b"401 Unauthorized\n"
+            authorized_calls.append(json.loads(request["body"]))
+            return 200, {"success": True, "issues": []}
+
+        with tempfile.TemporaryDirectory() as root, EditorHttpFixture(EDITOR_OPENAPI_1_13_2, respond) as server:
+            internal = Path(root) / ".internal"
+            internal.mkdir()
+            token_path = internal / "editor.token"
+            project = EditorApiClient(root, port=server.port)
+            token_path.write_text("old-session", encoding="utf-8")
+            with self.assertRaisesRegex(editor.CommandError, "authentication was rejected"):
+                project.bob()
+            self.assertEqual([], authorized_calls)
+            token_path.write_text("current-session", encoding="utf-8")
+            result = project.bob(options={"platform": "wasm-web", "archive": True}, commands=("build", "bundle"))
+            self.assertTrue(result.success)
+            self.assertEqual([{"options": {"platform": "wasm-web", "archive": True}, "commands": ["build", "bundle"]}], authorized_calls)
+            self.assertEqual(2, sum(request["method"] == "POST" for request in server.requests))
+
+
 class EditorDiscoveryUnitTest(unittest.TestCase):
     def setUp(self):
         directory = tempfile.TemporaryDirectory()
@@ -4086,7 +4208,8 @@ class AutomationBridgeApiTest(unittest.TestCase):
         port = self.bridge.port
         before = self.bridge.health()["identity"]
 
-        status, response = self.editor._json_command("build", timeout=20)
+        command = "run" if self.editor.commands.supports("run") else "build"
+        status, response = self.editor._json_command(command, timeout=20)
         self.assertEqual(200, status)
         self.assertTrue(response["success"], response.get("issues"))
 
@@ -4112,6 +4235,25 @@ class AutomationBridgeApiTest(unittest.TestCase):
         self.__class__.bridge = attached
         self.assertEqual(port, attached.port)
         self.assertEqual(after["identity"]["engine_instance_id"], attached.health()["identity"]["engine_instance_id"])
+
+    def test_editor_compile_and_bob_preserve_running_engine(self):
+        if self.editor is None or not self.editor.commands.supports("compile"):
+            raise unittest.SkipTest("compile and Bob require Defold 1.13.2 editor capabilities")
+        self.ensure_running_bridge()
+        before = self.bridge.health()["identity"]["engine_instance_id"]
+        result = self.editor.compile(timeout=60)
+        self.assertTrue(result.completed)
+        self.assertTrue(result.success)
+        self.assertIsNone(result.target_url)
+        self.assertEqual(before, self.bridge.health()["identity"]["engine_instance_id"])
+        result = self.editor.bob(options={"help": True}, timeout=60)
+        self.assertTrue(result.completed)
+        self.assertTrue(result.success)
+        self.assertIsNone(result.target_url)
+        self.assertEqual(before, self.bridge.health()["identity"]["engine_instance_id"])
+        self.editor.commands.hot_reload(timeout=60)
+        self.assertTrue(self.editor.last_command_result.completed)
+        self.assertTrue(self.editor.last_command_result.success)
 
     def test_drag_item_along_cubic_curve_and_closed_circle(self):
         self.ensure_running_bridge()


### PR DESCRIPTION
Automation can now check compilation and build bundles without launching the game, or compile and run without taking focus. Existing Defold 1.13.1 workflows remain compatible, with clear errors identifying features supported from Defold 1.13.2.

### Technical changes

- Support both OpenAPI discovery formats and expose command descriptions and parameter schemas through `commands.catalog()` and `commands.supports()`.
- Add `project.compile()` and authenticated `project.bob()`. Bob reads the editor session token on each call and does not automatically retry requests.
- Select `run` when advertised, falling back to legacy `build`. Default to `focus=false` where supported; reject unsupported explicit requests before engine cleanup.
- Preserve completion status, warnings, source locations, and optional target URLs in `BuildResult`, `last_command_result`, and `BuildError.result`. Existing helper return values remain unchanged.
- Connect through validated local target URLs and check bridge health, capabilities, and identity. Retain console discovery when the result omits a URL.
- Add versioned fixtures, HTTP compatibility tests, CI coverage, and updated documentation.

Validation: 218 unit and tooling tests passed. Live test runs passed on Defold 1.13.1 (228 tests) and 1.13.2 alpha (234 tests), including compile, run, authenticated Bob help, hot reload, and runtime workflows.