### PR TITLE
Fix Python cancellation cleanup and profiler targeting

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -87,6 +87,16 @@ still need the editor workflow. The ordinary command skips runtime tests when
 Defold is absent; `AUTOMATION_BRIDGE_REQUIRE_RUNTIME=1` turns unavailable runtime
 setup into a failure. It never launches the editor implicitly.
 
+Concurrent native validation projects need different available
+`[profiler] remotery_port` settings in `game.project`. Start a new engine process
+after changing that setting. An occupied Remotery port causes profiler startup
+to fail and can freeze the tested 1.13.1 and 1.13.2 alpha engines on in-process
+reboot. The wrapper reports missing profiler metadata instead of reading
+another game's default port. See the
+[Python profiler guidance](automation_bridge/automation-bridge-python/README.md#profiling)
+for connection setup and the verified workaround. Keep runtime tests enabled
+when validating this behavior.
+
 Editor compatibility tests serve the versioned fixtures in `tests/fixtures`
 through local HTTP servers. They cover 1.13.1 command enums and acknowledgements,
 1.13.2 command paths and focus, compile/run, structured completion and errors,

--- a/automation_bridge/automation-bridge-python/MIGRATION.md
+++ b/automation_bridge/automation-bridge-python/MIGRATION.md
@@ -24,6 +24,16 @@ Put short examples below it only when a table entry is not sufficient. Do not
 rename unrelated variables or valid Defold GUI terms such as `gui_node`,
 `gui_node_box`, and `gui_node_text`.
 
+## Wrapper 3.0 → next release: explicit profiler connections
+
+| Wrapper 3.0 | Next wrapper release |
+| --- | --- |
+| `game.profiler.connect()`, `capture()`, and `start_recording()` assume port 17815 when no URL was discovered. | Use the current engine's discovered URL. For direct attachment, pass `profiler_url` to `engine.connect()`, or pass a known `port`/`url` to the profiler helper. Missing metadata raises `engine.ProfilerError`. |
+
+Editor bootstrap discovers the current engine's URL. When startup reports a
+Remotery initialization failure, choose a distinct `profiler.remotery_port` and
+start a new engine process.
+
 ## Wrapper 2.x → 3.0 (extension 2.0.x → 2.1.0)
 
 Most documented high-level calls are unchanged, including `element()`,

--- a/automation_bridge/automation-bridge-python/README.md
+++ b/automation_bridge/automation-bridge-python/README.md
@@ -766,6 +766,24 @@ timing mode, or external services.
 All profiling is presented through `game.profiler`; the underlying stream
 protocol is an implementation detail.
 
+Editor connections discover the profiler URL from the current engine's startup
+logs, including engines that initialize Remotery after bridge registration. For
+structured launch results, bootstrap briefly polls for delayed console metadata;
+unavailable profiler metadata does not prevent connecting to the engine. If
+no URL was discovered, stream operations raise `engine.ProfilerError`. They do
+not guess port 17815, which may belong to a different game. Direct connections
+can supply `engine.connect(engine_port, profiler_url="ws://127.0.0.1:17816/rmt")`
+or use `game.profiler.connect(port=17816)` explicitly. Resource inspection through
+`game.profiler.resources()` uses the engine service and requires no stream URL.
+
+Concurrent games need distinct Remotery ports. Set `[profiler] remotery_port`
+in each game's `game.project`, then start a new engine process. A startup message
+`Failed to initialize Remotery: 5` can indicate an occupied port. In the tested
+Defold 1.13.1 and 1.13.2 alpha engines, this condition also caused an in-process
+reboot to stall inside the profiler; assigning an available port avoids that
+startup failure. This workaround requires a new process because an in-process
+reboot retains the profiler listener.
+
 ```python
 resources = game.profiler.resources()
 

--- a/automation_bridge/automation-bridge-python/README.md
+++ b/automation_bridge/automation-bridge-python/README.md
@@ -497,6 +497,11 @@ with game.pointer((100, 100)) as pointer:
 
 The pointer object exposes its configured `lease`, `input_id`, and `closed`
 state. `game.input.status(pointer.input_id)` returns its current native receipt.
+Pointer and input-interruption contexts preserve the original cancellation
+exception when cleanup fails. Inspect `OperationCancelled.cleanup_error` for
+the first cleanup failure. A pointer whose cancellation was refused remains
+open, so its native receipt can be inspected before retrying `pointer.cancel()`.
+
 To capture a rendered pressed state, request a frame-relative screenshot while
 the pointer context is still open and choose a lease that comfortably covers
 the capture:

--- a/automation_bridge/automation-bridge-python/automation_bridge/client.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/client.py
@@ -269,12 +269,13 @@ class EngineLogStream:
                         raise
 
 
-def _cleanup_without_masking(cleanup: Any) -> None:
-    """Run best-effort cleanup while preserving an already-active exception."""
+def _cleanup_without_masking(cleanup: Any, interrupted: Optional[BaseException] = None) -> None:
+    """Preserve the original exception and retain cancellation cleanup evidence."""
     try:
         cleanup()
-    except BaseException:
-        pass
+    except BaseException as cleanup_error:
+        if isinstance(interrupted, OperationCancelled) and interrupted.cleanup_error is None:
+            interrupted.cleanup_error = cleanup_error
 
 
 class RuntimeLogs:
@@ -359,7 +360,10 @@ class RuntimeLogs:
 
 
 class InputInterruptionScope:
-    """Flush this client's input session if an enclosed operation is interrupted."""
+    """Flush this client's input session if an enclosed operation is interrupted.
+
+    Refused cleanup is retained on ``OperationCancelled.cleanup_error``.
+    """
 
     def __init__(self, controller: "InputController", flush: bool, release: bool):
         self._controller = controller
@@ -373,7 +377,7 @@ class InputInterruptionScope:
         if exc_type is None:
             return
         if self.flush:
-            _cleanup_without_masking(lambda: self._controller.flush(release=self.release))
+            _cleanup_without_masking(lambda: self._controller.flush(release=self.release), exc)
 
 
 class InputController:
@@ -486,12 +490,16 @@ class InputController:
         queueing input with ``wait=False``. With ``flush=True`` (the default),
         both the active action and later actions owned by this client session
         are cancelled. Cleanup failures never mask the original exception.
+        Inspect ``OperationCancelled.cleanup_error`` when cleanup is refused.
         """
         return InputInterruptionScope(self, flush=flush, release=release)
 
 
 class PointerSession:
-    """Leased low-level pointer that guarantees up/cancel cleanup in a context manager."""
+    """Leased low-level pointer with up/cancel cleanup in a context manager.
+
+    Refused cleanup is retained on ``OperationCancelled.cleanup_error``.
+    """
 
     def __init__(self, bridge: "Client", receipt: InputReceipt, lease: float):
         self._bridge = bridge
@@ -510,7 +518,7 @@ class PointerSession:
         if self.closed:
             return
         if exc_type is not None:
-            _cleanup_without_masking(self.cancel)
+            _cleanup_without_masking(self.cancel, exc)
             return
         self.up()
 

--- a/automation_bridge/automation-bridge-python/automation_bridge/client.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/client.py
@@ -813,12 +813,21 @@ class Client:
         if self._closed:
             raise AutomationBridgeError("engine client is closed; reconnect to continue")
 
+    def _flush_owned_input(self) -> None:
+        """Request cleanup only when native receipts belong to this session."""
+        # Flushing acquires a controller lease, even when the queue is empty.
+        # An idle observer must not take control merely because it is cancelled.
+        if any(receipt.get("client_id") == self.client_id and receipt.get("session_id") == self.session_id
+               for receipt in self.input.pending()):
+            self.input.flush(release=True)
+
     @contextmanager
     def cancellation_scope(self, token: CancellationToken):
         """Cancel waits and request release of this session's input on cancellation.
 
         One token belongs to one operation. Use separate clients/identities for
         independent operations; cleanup only targets this client's native lease.
+        Idle observers do not acquire control during cancellation cleanup.
         A cleanup failure is retained on ``OperationCancelled.cleanup_error``.
         """
         entered = False
@@ -829,7 +838,7 @@ class Client:
         except OperationCancelled as exc:
             if entered:
                 try:
-                    self.input.flush(release=True)
+                    self._flush_owned_input()
                 except Exception as cleanup_error:
                     if exc.cleanup_error is None:
                         exc.cleanup_error = cleanup_error

--- a/automation_bridge/automation-bridge-python/automation_bridge/client.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/client.py
@@ -948,8 +948,7 @@ class Client:
             lifecycle = health.get("lifecycle", {})
             if isinstance(lifecycle, Mapping) and lifecycle.get("current_stage") == "initial_scene_ready":
                 editor._record_lifecycle("initial_scene_ready", engine_instance_id=bridge.engine_instance_id)
-            if profiler_url:
-                editor._remember_remotery_url(profiler_url)
+            editor._remember_remotery_url(profiler_url)
             bridge.logs.start()
             bridge._owns_engine = fresh_build
             bridge._project_root = Path(editor.root)
@@ -978,21 +977,20 @@ class Client:
                 if bridge is not None:
                     # The engine URL is authoritative; console metadata is optional.
                     try:
-                        console_lines = editor._console_lines()
-                        if target_port in editor._current_registration_engine_service_ports(console_lines):
-                            profiler_url = cls._editor_profiler_url(editor, fresh_build=True, console_lines=console_lines)
-                            if profiler_url:
-                                bridge._remotery_url = profiler_url
-                                editor._remember_remotery_url(profiler_url)
-                    except AutomationBridgeError:
-                        pass
+                        profiler_url = editor._reported_target_remotery_url(target_port, timeout)
+                    except BaseException as exc:
+                        _cleanup_without_masking(bridge.close, exc)
+                        raise
+                    if profiler_url:
+                        bridge._remotery_url = profiler_url
+                        editor._remember_remotery_url(profiler_url)
                 return bridge
             console_lines = editor._console_lines()
             service_ports = editor._engine_service_ports(console_lines)
             registration_ports = editor._current_registration_engine_service_ports(console_lines)
             profiler_url = cls._editor_profiler_url(
                 editor,
-                fresh_build=fresh_build,
+                fresh_build=fresh_build or bool(registration_ports),
                 console_lines=console_lines,
             )
             for service_port in service_ports:

--- a/automation_bridge/automation-bridge-python/automation_bridge/editor.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/editor.py
@@ -37,6 +37,7 @@ _AUTOMATION_BRIDGE_REPOSITORY = "https://github.com/defold/extension-automation-
 _AUTOMATION_BRIDGE_LATEST_RELEASE_API = "https://api.github.com/repos/defold/extension-automation-bridge/releases/latest"
 _AUTOMATION_BRIDGE_PYTHON_DIRECTORY = "automation-bridge-python"
 _EDITOR_ABSENCE_GRACE_PERIOD = 5.0
+_PROFILER_DISCOVERY_GRACE_PERIOD = 1.0
 _DEPENDENCY_LINE_PATTERN = re.compile(r"^(\s*dependencies#(\d+)\s*=\s*)(.*?)([ \t]*(?:\r\n|\n|\r)?)$")
 _SECTION_PATTERN = re.compile(r"^\s*\[([^]]+)\]\s*(?:\r\n|\n|\r)?$")
 _ENGINE_SERVICE_PORT_PATTERNS = (
@@ -1514,10 +1515,36 @@ class Client:
         return candidates
 
     def _current_registration_remotery_urls(self, lines: Optional[list] = None) -> list:
-        """Return Remotery websocket URLs logged before the latest endpoint registration only."""
+        """Return Remotery URLs from the latest engine initialization."""
         if lines is None:
             lines = self._console_lines()
         return self._latest_registration_remotery_urls(lines)
+
+    def _reported_target_remotery_url(self, port: int, timeout: float) -> Optional[str]:
+        """Collect optional profiler metadata after a structured launch result.
+
+        The editor's console can lag its target URL and the engine's health.
+        Python owns this bounded discovery grace; it does not change native
+        readiness, retry the build, or require a profiler for a usable engine.
+        """
+        def discover():
+            lines = self._console_lines()
+            if port not in self._current_registration_engine_service_ports(lines):
+                return None
+            urls = self._current_registration_remotery_urls(lines)
+            if urls:
+                return (urls[0],)
+            initialization = self._latest_registration_window(lines, include_initialization=True) or ()
+            if any("Failed to initialize Remotery" in line or "Registered automation_bridge extension" in line
+                   for line in initialization):
+                return (None,)
+            return None
+
+        try:
+            result = wait_until(discover, timeout=min(timeout, _PROFILER_DISCOVERY_GRACE_PERIOD), interval=0.05)
+            return result[0]
+        except (AutomationBridgeError, WaitTimeoutError):
+            return None
 
     @classmethod
     def _latest_registration_engine_service_ports(cls, lines: list) -> list:
@@ -1534,14 +1561,19 @@ class Client:
 
     @classmethod
     def _latest_registration_remotery_urls(cls, lines: list) -> list:
-        search_lines = cls._latest_registration_window(lines)
+        search_lines = cls._latest_registration_window(lines, include_initialization=True)
         if search_lines is None:
             search_lines = lines
         candidates = []
-        for line in reversed(search_lines):
+        for line in search_lines:
+            if "Failed to initialize Remotery" in line:
+                candidates.clear()
             match = _REMOTERY_URL_PATTERN.search(line)
             if match:
-                cls._append_unique_candidate(candidates, match.group(1))
+                url = match.group(1)
+                if url in candidates:
+                    candidates.remove(url)
+                candidates.insert(0, url)
         return candidates
 
     def _latest_registration_has_engine_service_port(self) -> bool:
@@ -1561,7 +1593,7 @@ class Client:
         return bool(current_count and current_ports and current_ports != previous_ports)
 
     @staticmethod
-    def _latest_registration_window(lines: list) -> Optional[list]:
+    def _latest_registration_window(lines: list, *, include_initialization: bool = False) -> Optional[list]:
         endpoint_index: Optional[int] = None
         previous_endpoint_index: Optional[int] = None
         for index, line in enumerate(lines):
@@ -1572,6 +1604,15 @@ class Client:
         if endpoint_index is None:
             return None
         start_index = previous_endpoint_index + 1 if previous_endpoint_index is not None else 0
+        if include_initialization:
+            # Extension initialization order differs between engines. Remotery
+            # can log after AppInitialize registers our endpoint. Exclude the
+            # preceding engine's remaining initialization before searching both
+            # sides of the current registration.
+            for index in range(start_index, endpoint_index):
+                if "Registered automation_bridge extension" in lines[index]:
+                    start_index = index + 1
+            return lines[start_index:]
         return lines[start_index:endpoint_index]
 
     def _remember_engine_service_port(
@@ -1649,10 +1690,13 @@ class Client:
         """Return a copy of editor/bootstrap lifecycle events observed by this client."""
         return [dict(event) for event in self._lifecycle_events]
 
-    def _remember_remotery_url(self, url: str) -> None:
-        """Remember the Remotery websocket URL for reused-engine builds."""
+    def _remember_remotery_url(self, url: Optional[str]) -> None:
+        """Replace profiler metadata, clearing a preceding engine's stale URL."""
         self._remotery_url = url
-        self._write_cached_remotery_url(url)
+        if url is None:
+            self._remotery_url_cache_path.unlink(missing_ok=True)
+        else:
+            self._write_cached_remotery_url(url)
 
     @staticmethod
     def _append_port_candidate(candidates: list, port: int) -> None:

--- a/automation_bridge/automation-bridge-python/automation_bridge/profiler.py
+++ b/automation_bridge/automation-bridge-python/automation_bridge/profiler.py
@@ -126,14 +126,22 @@ class ProfilerClient:
         """Return a live engine profiler connection.
 
         By default this uses the profiler URL discovered while bootstrapping
-        from editor logs. Pass `url`, or `host`/`port`, to override it.
+        from editor logs. Pass `url`, or `port` with an optional `host`, to
+        override it. Without a discovered URL or an explicit port, raise
+        ProfilerError instead of connecting to another engine on a default port.
         """
         if url is not None:
             return ProfilerConnection.from_url(url, timeout=self.timeout)
         if port is None and host is None and self._remotery_url is not None:
             return ProfilerConnection.from_url(self._remotery_url, timeout=self.timeout)
+        if port is None:
+            raise ProfilerError(
+                "No Remotery URL was discovered for this engine. Check its startup console "
+                "for profiler initialization errors, or pass an explicit profiler url or port. "
+                "Concurrent engines need distinct profiler.remotery_port settings."
+            )
         return ProfilerConnection(
-            port=_remotery.DEFAULT_REMOTERY_PORT if port is None else port,
+            port=port,
             host="127.0.0.1" if host is None else host,
             path=path,
             timeout=self.timeout,

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -327,7 +327,8 @@ class EngineClientUnitTest(unittest.TestCase):
     def test_client_scope_releases_its_input_when_scene_wait_is_cancelled(self):
         bridge = FakeInputClient()
         token = engine.CancellationToken()
-        with self.assertRaises(engine.OperationCancelled):
+        pending = [{'input_id': 42, 'client_id': bridge.client_id, 'session_id': bridge.session_id}]
+        with mock.patch.object(bridge.input, 'pending', return_value=pending), self.assertRaises(engine.OperationCancelled):
             with bridge.cancellation_scope(token):
                 bridge.key("SPACE", hold=1, wait=False)
                 wait_until(lambda: token.cancel())
@@ -336,6 +337,46 @@ class EngineClientUnitTest(unittest.TestCase):
         self.assertEqual(bridge.client_id, values["client_id"])
         self.assertEqual(bridge.session_id, values["session_id"])
         self.assertTrue(values["release"])
+
+    def test_cancelled_observer_does_not_acquire_input_control(self):
+        bridge = engine.Client(54321)
+        self.addCleanup(bridge.close)
+        for receipts in ([], [{'client_id': 'other', 'session_id': bridge.session_id}],
+                         [{'client_id': bridge.client_id, 'session_id': 'other'}]):
+            token = engine.CancellationToken()
+            with self.subTest(receipts=receipts), \
+                 mock.patch.object(bridge.input, 'pending', return_value=receipts) as pending, \
+                 mock.patch.object(bridge.input, 'flush') as flush:
+                with self.assertRaises(engine.OperationCancelled) as error:
+                    with bridge.cancellation_scope(token):
+                        token.cancel('observer stopped')
+                self.assertEqual('observer stopped', str(error.exception))
+                self.assertIsNone(error.exception.cleanup_error)
+                pending.assert_called_once_with()
+                flush.assert_not_called()
+
+    def test_client_cancellation_retains_receipt_and_cleanup_failures(self):
+        bridge = engine.Client(54321)
+        self.addCleanup(bridge.close)
+        receipts = [engine.InputReceipt({'input_id': 42, 'client_id': bridge.client_id,
+                                         'session_id': bridge.session_id})]
+        for failed_operation in ('pending', 'flush'):
+            token = engine.CancellationToken()
+            refusal = RuntimeError('native cleanup unavailable')
+            with self.subTest(failed_operation=failed_operation), \
+                 mock.patch.object(bridge.input, 'pending', return_value=receipts,
+                                   side_effect=refusal if failed_operation == 'pending' else None), \
+                 mock.patch.object(bridge.input, 'flush',
+                                   side_effect=refusal if failed_operation == 'flush' else None) as flush:
+                with self.assertRaises(engine.OperationCancelled) as error:
+                    with bridge.cancellation_scope(token):
+                        token.cancel('caller stopped')
+                self.assertEqual('caller stopped', str(error.exception))
+                self.assertIs(refusal, error.exception.cleanup_error)
+                if failed_operation == 'pending':
+                    flush.assert_not_called()
+                else:
+                    flush.assert_called_once_with(release=True)
 
     def test_command_cancellation_preserves_native_refusal(self):
         bridge = FakeInputClient()

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -2623,6 +2623,14 @@ class EngineClientUnitTest(unittest.TestCase):
         self.assertEqual(23456, connection.port)
         self.assertEqual(3.0, connection.timeout)
 
+    def test_profiler_connection_requires_engine_metadata_or_an_explicit_port(self):
+        profiler = ProfilerClient(12345, timeout=3.0)
+        with mock.patch('automation_bridge.profiler.ProfilerConnection') as connection:
+            for kwargs in ({}, {'host': 'localhost'}):
+                with self.subTest(kwargs=kwargs), self.assertRaisesRegex(engine.ProfilerError, 'No Remotery URL was discovered'):
+                    profiler.connect(**kwargs)
+            connection.assert_not_called()
+
     def test_editor_latest_registration_remotery_urls(self):
         lines = [
             "INFO:ENGINE: Initialized Remotery (ws://127.0.0.1:11111/rmt)",
@@ -2633,6 +2641,74 @@ class EngineClientUnitTest(unittest.TestCase):
         ]
 
         self.assertEqual(["ws://127.0.0.1:22222/rmt"], EditorApiClient._latest_registration_remotery_urls(lines))
+
+    def test_profiler_discovery_covers_both_sides_of_current_registration(self):
+        previous = [
+            'INFO:AUTOMATIONBRIDGE: Automation Bridge endpoint registered',
+            'INFO:PROFILER: Initialized Remotery (ws://127.0.0.1:11111/rmt)',
+            'INFO:AUTOMATIONBRIDGE: Registered automation_bridge extension',
+        ]
+        registration = ['INFO:ENGINE: Engine service started on port 33333',
+                        'INFO:AUTOMATIONBRIDGE: Automation Bridge endpoint registered']
+        ready = 'INFO:PROFILER: Initialized Remotery (ws://127.0.0.1:22222/rmt)'
+        failed = 'ERROR:PROFILER: Failed to initialize Remotery: 5'
+        for current, expected in (
+            ([ready, *registration], ['ws://127.0.0.1:22222/rmt']),
+            ([*registration, ready], ['ws://127.0.0.1:22222/rmt']),
+            (registration, []),
+            ([failed, *registration], []),
+            ([ready, *registration, failed], []),
+        ):
+            with self.subTest(current=current):
+                self.assertEqual(expected, EditorApiClient._latest_registration_remotery_urls(previous + current))
+
+    def test_reported_target_waits_for_delayed_profiler_console_metadata(self):
+        project = EditorApiClient('.', port=12345)
+        registration = ['INFO:ENGINE: Engine service started on port 54321',
+                        'INFO:AUTOMATIONBRIDGE: Automation Bridge endpoint registered']
+        ready = [*registration, 'INFO:PROFILER: Initialized Remotery (ws://127.0.0.1:54322/rmt)']
+        with mock.patch.object(project, '_console_lines', side_effect=[[], registration, ready]) as console:
+            self.assertEqual('ws://127.0.0.1:54322/rmt', project._reported_target_remotery_url(54321, 0.5))
+        self.assertEqual(3, console.call_count)
+
+    def test_reported_target_allows_missing_profiler_metadata_and_preserves_cancellation(self):
+        project = EditorApiClient('.', port=12345)
+        registration = ['INFO:ENGINE: Engine service started on port 54321',
+                        'INFO:AUTOMATIONBRIDGE: Automation Bridge endpoint registered']
+        for line in ('ERROR:PROFILER: Failed to initialize Remotery: 5',
+                     'INFO:AUTOMATIONBRIDGE: Registered automation_bridge extension'):
+            with self.subTest(line=line), mock.patch.object(project, '_console_lines', return_value=[*registration, line]) as console:
+                self.assertIsNone(project._reported_target_remotery_url(54321, 0.5))
+                console.assert_called_once_with()
+        with mock.patch.object(project, '_console_lines', return_value=[]):
+            self.assertIsNone(project._reported_target_remotery_url(54321, 0.001))
+        with mock.patch.object(project, '_console_lines', side_effect=AutomationBridgeError('console unavailable')):
+            self.assertIsNone(project._reported_target_remotery_url(54321, 0.5))
+        with mock.patch.object(project, '_console_lines', side_effect=engine.OperationCancelled('cancel discovery')):
+            with self.assertRaises(engine.OperationCancelled):
+                project._reported_target_remotery_url(54321, 0.5)
+
+    def test_new_engine_registration_clears_previous_profiler_cache(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / 'game.project').write_text('[project]\ntitle = fixture\n')
+            project = EditorApiClient(root, port=12345)
+            project._remember_remotery_url('ws://127.0.0.1:17815/rmt')
+            console = ['ERROR:PROFILER: Failed to initialize Remotery: 5',
+                       'INFO:ENGINE: Engine service started on port 54321',
+                       'INFO:AUTOMATIONBRIDGE: Automation Bridge endpoint registered']
+            health = {'identity': {'engine_instance_id': 'engine:new', 'project_identity': 'project:fixture', 'process_id': 42}}
+            with mock.patch.object(project, '_console_lines', return_value=console), \
+                 mock.patch.object(EngineClient, 'health', return_value=health), \
+                 mock.patch('automation_bridge.client.RuntimeLogs.start'):
+                bridge = EngineClient._from_editor(project, timeout=0.1)
+            try:
+                self.assertIsNone(bridge.profiler_url)
+                self.assertIsNone(project._cached_remotery_url_value())
+                self.assertFalse(project._remotery_url_cache_path.exists())
+                self.assertIsNone(EditorApiClient(root, port=12345)._cached_remotery_url_value())
+            finally:
+                bridge.close()
 
     def test_parse_remotery_sample_frame(self):
         frame = parse_sample_frame(_remotery_sample_frame_body(), {1: "Frame", 2: "Update"})

--- a/tests/test_automation_bridge_api.py
+++ b/tests/test_automation_bridge_api.py
@@ -2357,6 +2357,40 @@ class EngineClientUnitTest(unittest.TestCase):
             with bridge.pointer((10, 20), lease=2.0):
                 raise KeyboardInterrupt("stop")
 
+    def test_pointer_cancellation_preserves_cleanup_failure_and_allows_retry(self):
+        bridge = FakeInputClient()
+        original = engine.OperationCancelled('caller stopped')
+        refusal = RuntimeError('native cleanup refused')
+        with mock.patch.object(bridge.input, 'cancel', side_effect=refusal) as cancel:
+            with self.assertRaises(engine.OperationCancelled) as error:
+                with bridge.pointer((10, 20), lease=2.0) as pointer:
+                    raise original
+            cancel.assert_called_once_with(pointer.input_id, release=True)
+        self.assertIs(original, error.exception)
+        self.assertIs(refusal, error.exception.cleanup_error)
+        self.assertFalse(pointer.closed)
+        receipt = engine.InputReceipt({'input_id': pointer.input_id, 'state': 'cancelled'})
+        with mock.patch.object(bridge.input, 'cancel', return_value=receipt) as retry:
+            self.assertIs(receipt, pointer.cancel())
+            retry.assert_called_once_with(pointer.input_id, release=True)
+        self.assertTrue(pointer.closed)
+
+    def test_input_interruption_scope_preserves_first_cancellation_cleanup_error(self):
+        bridge = FakeInputClient()
+        for earlier_error in (None, RuntimeError('earlier cleanup refused')):
+            original = engine.OperationCancelled('caller stopped')
+            original.cleanup_error = earlier_error
+            refusal = RuntimeError('native cleanup refused')
+            with self.subTest(earlier_error=earlier_error), \
+                 mock.patch.object(bridge.input, 'flush', side_effect=refusal) as flush:
+                with self.assertRaises(engine.OperationCancelled) as error:
+                    with bridge.input.interruption_scope():
+                        raise original
+                flush.assert_called_once_with(release=True)
+            self.assertIs(original, error.exception)
+            self.assertIs(earlier_error if earlier_error is not None else refusal,
+                          error.exception.cleanup_error)
+
     def test_orientation_helpers_swap_last_known_size(self):
         bridge = FakeEngineClient({"window": {"width": 320, "height": 568}})
 


### PR DESCRIPTION
Cancelling an idle Python automation client no longer takes input control from other clients. Pointer cleanup failures remain available for inspection and retry. Profiling discovers the current game's address reliably and reports missing metadata instead of silently connecting to another game's default profiler port.

### Technical changes

- Check pending input ownership before cancellation cleanup and preserve the first cleanup failure on `OperationCancelled.cleanup_error`.
- Discover profiler URLs across startup-log ordering and delayed console delivery, clear stale cached URLs, and close clients when bootstrap discovery is interrupted.
- Require a discovered profiler URL or an explicit `url`/`port`; missing metadata now raises `engine.ProfilerError`. Add migration and profiler port-isolation guidance, including the remaining native reboot limitation.
- Add standalone regression coverage for input ownership, cleanup failures and retry, profiler discovery, and explicit connection targets.
- Validation: `PYTHONPATH=automation_bridge/automation-bridge-python python3 -m unittest tests.test_automation_bridge_api tests.test_tooling` passed 227 tests. Live runtime setup was skipped because no editor was open for the worktree.
